### PR TITLE
feat(ingest): carry trust_score/trust_level from chitin events

### DIFF
--- a/internal/ingestion/chitin_governance.go
+++ b/internal/ingestion/chitin_governance.go
@@ -26,6 +26,8 @@ type chitinEvent struct {
 	Source      string                 `json:"source"` // "policy", "invariant", etc.
 	LatencyUs   int64                  `json:"latency_us"`
 	Explanation map[string]interface{} `json:"explanation,omitempty"`
+	TrustScore  *int                   `json:"trust_score,omitempty"`
+	TrustLevel  string                 `json:"trust_level,omitempty"`
 }
 
 // ChitinGovernanceAdapter reads .chitin/events.jsonl from configured workspace
@@ -161,6 +163,12 @@ func (a *ChitinGovernanceAdapter) readFile(path string, offset int64) ([]Executi
 		}
 		if ce.Command != "" {
 			ev.Tags["command"] = ce.Command
+		}
+		if ce.TrustScore != nil {
+			ev.Tags["trust_score"] = strconv.Itoa(*ce.TrustScore)
+		}
+		if ce.TrustLevel != "" {
+			ev.Tags["trust_level"] = ce.TrustLevel
 		}
 		events = append(events, ev)
 		seq++


### PR DESCRIPTION
## Summary
- Parse `trust_score` (*int, preserves 0) and `trust_level` from chitin `events.jsonl`
- Forward both into `execution_events.tags` JSONB for downstream correlation

## Context
Pairs with chitinhq/chitin#59 which adds per-agent trust scoring to governance events. No migration needed — `tags` column is JSONB.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./internal/ingestion/...` passing
- [ ] Verify trust_score=0 survives end-to-end (blocked on #59 merging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)