### PR TITLE
feat(analyzer): mcp_usage pass — partition governance events by mcp__ prefix

### DIFF
--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -81,6 +81,13 @@ func (a *Analyzer) Run(ctx context.Context) ([]Finding, error) {
 	log.Printf("sentinel: pass 4 (tool risk) found %d findings", len(toolRisks))
 	all = append(all, toolRisks...)
 
+	// Pass 4b: MCP usage profiling — partitions action counts on the mcp__
+	// prefix so we can see which MCP tools are actually being leaned on.
+	// Uses the same input as pass 1 (hotspot), scoped to MCP-only events.
+	mcpUsage := ProfileMCPUsage(counts)
+	log.Printf("sentinel: pass 4b (mcp usage) found %d findings", len(mcpUsage))
+	all = append(all, mcpUsage...)
+
 	// Pass 5: Anomaly detection
 	volumes, err := a.store.QueryHourlyVolumes(ctx, since)
 	if err != nil {

--- a/internal/analyzer/mcpusage.go
+++ b/internal/analyzer/mcpusage.go
@@ -27,6 +27,11 @@ func mcpServer(action string) string {
 	if i <= 0 {
 		return ""
 	}
+	// Tool segment (everything after the server's trailing "__") must be
+	// non-empty — "mcp__octi__" is not a valid MCP tool invocation.
+	if i+2 >= len(rest) {
+		return ""
+	}
 	return rest[:i]
 }
 
@@ -85,7 +90,11 @@ func ProfileMCPUsage(counts []db.ActionCount) []Finding {
 	// agents actually leaning on" before "what's failing" — failures are
 	// covered by the existing hotspot pass.
 	sort.Slice(findings, func(i, j int) bool {
-		return findings[i].Metrics.Count > findings[j].Metrics.Count
+		if findings[i].Metrics.Count != findings[j].Metrics.Count {
+			return findings[i].Metrics.Count > findings[j].Metrics.Count
+		}
+		// Tie-break on PolicyID so output is deterministic across runs.
+		return findings[i].PolicyID < findings[j].PolicyID
 	})
 
 	return findings

--- a/internal/analyzer/mcpusage.go
+++ b/internal/analyzer/mcpusage.go
@@ -1,0 +1,92 @@
+package analyzer
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/chitinhq/sentinel/internal/db"
+)
+
+// MCPToolPrefix identifies MCP tool invocations in governance events.
+// MCP tool names follow the convention mcp__<server>__<tool>, emitted by
+// the mcptrace package in octi-pulpo, atlas, and (in future) other MCP
+// servers so they land alongside chitin governance events in events.jsonl.
+const MCPToolPrefix = "mcp__"
+
+// mcpServer extracts the server name from an MCP tool action.
+// "mcp__octi__sprint_status" -> "octi". Returns "" if the action is not
+// an MCP tool.
+func mcpServer(action string) string {
+	if !strings.HasPrefix(action, MCPToolPrefix) {
+		return ""
+	}
+	rest := action[len(MCPToolPrefix):]
+	i := strings.Index(rest, "__")
+	if i <= 0 {
+		return ""
+	}
+	return rest[:i]
+}
+
+// ProfileMCPUsage rolls up MCP tool invocations from action counts and
+// emits findings for (1) high-volume tools — so we can see what's carrying
+// weight, and (2) tools with elevated denial rates — which suggests the
+// tool interface is confusing or the policy surface around it is wrong.
+//
+// Non-MCP actions are ignored; this pass complements hotspot/toolrisk
+// rather than duplicating them.
+func ProfileMCPUsage(counts []db.ActionCount) []Finding {
+	type toolStats struct {
+		server  string
+		total   int
+		denials int
+	}
+	byTool := make(map[string]*toolStats)
+
+	for _, c := range counts {
+		server := mcpServer(c.Action)
+		if server == "" {
+			continue
+		}
+		s, ok := byTool[c.Action]
+		if !ok {
+			s = &toolStats{server: server}
+			byTool[c.Action] = s
+		}
+		s.total += c.Count
+		if c.Outcome == "deny" {
+			s.denials += c.Count
+		}
+	}
+
+	var findings []Finding
+	now := time.Now()
+	for tool, s := range byTool {
+		if s.total == 0 {
+			continue
+		}
+		rate := float64(s.denials) / float64(s.total)
+		findings = append(findings, Finding{
+			ID:       fmt.Sprintf("mcpusage-%s-%d", tool, now.Unix()),
+			Pass:     "mcp_usage",
+			PolicyID: tool,
+			Metrics: Metrics{
+				Count:      s.total,
+				Rate:       rate,
+				SampleSize: s.total,
+			},
+			DetectedAt: now,
+		})
+	}
+
+	// Order by raw call volume, highest first. That surfaces "what are
+	// agents actually leaning on" before "what's failing" — failures are
+	// covered by the existing hotspot pass.
+	sort.Slice(findings, func(i, j int) bool {
+		return findings[i].Metrics.Count > findings[j].Metrics.Count
+	})
+
+	return findings
+}

--- a/internal/analyzer/mcpusage_test.go
+++ b/internal/analyzer/mcpusage_test.go
@@ -1,0 +1,85 @@
+package analyzer
+
+import (
+	"testing"
+
+	"github.com/chitinhq/sentinel/internal/db"
+)
+
+func TestMCPServer(t *testing.T) {
+	cases := []struct {
+		action, want string
+	}{
+		{"mcp__octi__sprint_status", "octi"},
+		{"mcp__atlas__wiki_search", "atlas"},
+		{"Bash", ""},
+		{"mcp__", ""},
+		{"mcp__bad", ""},            // no trailing __<tool>
+		{"mcp____tool", ""},         // empty server segment
+		{"something_else", ""},
+	}
+	for _, c := range cases {
+		if got := mcpServer(c.action); got != c.want {
+			t.Errorf("mcpServer(%q): want %q, got %q", c.action, c.want, got)
+		}
+	}
+}
+
+func TestProfileMCPUsage(t *testing.T) {
+	counts := []db.ActionCount{
+		{Action: "mcp__octi__sprint_status", Outcome: "allow", Count: 42},
+		{Action: "mcp__octi__sprint_status", Outcome: "deny", Count: 2},
+		{Action: "mcp__atlas__wiki_read", Outcome: "allow", Count: 10},
+		{Action: "mcp__atlas__wiki_edit", Outcome: "deny", Count: 3}, // all-deny tool
+		{Action: "Bash", Outcome: "allow", Count: 500},              // ignored
+		{Action: "Read", Outcome: "allow", Count: 200},              // ignored
+	}
+
+	findings := ProfileMCPUsage(counts)
+
+	if len(findings) != 3 {
+		t.Fatalf("want 3 findings (one per MCP tool), got %d", len(findings))
+	}
+
+	// Expect highest-volume tool first.
+	if findings[0].PolicyID != "mcp__octi__sprint_status" {
+		t.Errorf("top finding should be sprint_status, got %q", findings[0].PolicyID)
+	}
+	if findings[0].Metrics.Count != 44 {
+		t.Errorf("sprint_status total count: want 44, got %d", findings[0].Metrics.Count)
+	}
+	if rate := findings[0].Metrics.Rate; rate < 0.04 || rate > 0.05 {
+		t.Errorf("sprint_status denial rate should be ~0.045, got %f", rate)
+	}
+
+	// All-deny tool: rate == 1.0.
+	var editFinding *Finding
+	for i := range findings {
+		if findings[i].PolicyID == "mcp__atlas__wiki_edit" {
+			editFinding = &findings[i]
+		}
+	}
+	if editFinding == nil {
+		t.Fatal("wiki_edit finding not emitted")
+	}
+	if editFinding.Metrics.Rate != 1.0 {
+		t.Errorf("wiki_edit denial rate: want 1.0, got %f", editFinding.Metrics.Rate)
+	}
+
+	// Ensure every finding is tagged as the mcp_usage pass.
+	for _, f := range findings {
+		if f.Pass != "mcp_usage" {
+			t.Errorf("Pass field: want mcp_usage, got %q", f.Pass)
+		}
+	}
+}
+
+func TestProfileMCPUsage_NoMCPEventsReturnsEmpty(t *testing.T) {
+	counts := []db.ActionCount{
+		{Action: "Bash", Outcome: "allow", Count: 100},
+		{Action: "Edit", Outcome: "deny", Count: 5},
+	}
+	if got := ProfileMCPUsage(counts); len(got) != 0 {
+		t.Errorf("want no findings for non-MCP input, got %d", len(got))
+	}
+}

--- a/internal/analyzer/mcpusage_test.go
+++ b/internal/analyzer/mcpusage_test.go
@@ -16,6 +16,8 @@ func TestMCPServer(t *testing.T) {
 		{"mcp__", ""},
 		{"mcp__bad", ""},            // no trailing __<tool>
 		{"mcp____tool", ""},         // empty server segment
+		{"mcp__octi__", ""},         // empty tool segment
+		{"mcp__octi", ""},           // no tool separator
 		{"something_else", ""},
 	}
 	for _, c := range cases {


### PR DESCRIPTION
## Summary
- New \`ProfileMCPUsage\` pass (pass 4b): partitions QueryActionCounts rollup on \`mcp__\` prefix
- Per-MCP-tool findings: total calls + denial rate, sorted by volume
- Complements hotspot/toolrisk rather than duplicating

## Why P0
First sentinel pass that answers \"which MCP tools are agents actually leaning on\" — the core dogfooding question.

## Pairs with
- chitinhq/octi#<TBD> — mcptrace emitter
- chitinhq/atlas#<TBD> — same

## Test
\`go test ./internal/analyzer/\` — 3 new test cases cover prefix parsing, multi-tool roll-up, and non-MCP input.