### PR TITLE
feat(heartbeat): alert when governance_events/24h falls below threshold

### DIFF
--- a/cmd/sentinel/main.go
+++ b/cmd/sentinel/main.go
@@ -539,8 +539,11 @@ func runHeartbeat() (int, error) {
 
 	dec, err := heartbeat.Run(ctx, counter, notifier, cfg.Heartbeat.MinEvents24h)
 	if err != nil {
-		// If the notifier failed but we still have a decision, log and continue.
-		log.Printf("sentinel heartbeat: %v", err)
+		// A counter error means we can't tell if the pipeline is alive.
+		// Treat that as a hard failure: log and exit nonzero rather than
+		// pretending green. Notifier-only failures still surface here but
+		// we prefer a loud exit over a silent "OK".
+		return 1, fmt.Errorf("heartbeat run: %w", err)
 	}
 	if dec.Paging {
 		log.Printf("sentinel heartbeat PAGE: %d events in last 24h (threshold %d)", dec.Count, dec.Threshold)

--- a/cmd/sentinel/main.go
+++ b/cmd/sentinel/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/chitinhq/sentinel/internal/config"
 	"github.com/chitinhq/sentinel/internal/db"
 	"github.com/chitinhq/sentinel/internal/health"
+	"github.com/chitinhq/sentinel/internal/heartbeat"
 	"github.com/chitinhq/sentinel/internal/ingestion"
 	"github.com/chitinhq/sentinel/internal/insights"
 	"github.com/chitinhq/sentinel/internal/interpreter"
@@ -24,7 +25,7 @@ import (
 
 func main() {
 	if len(os.Args) < 2 {
-		fmt.Fprintln(os.Stderr, "usage: sentinel <analyze|digest|ingest>")
+		fmt.Fprintln(os.Stderr, "usage: sentinel <analyze|digest|ingest|health|heartbeat>")
 		os.Exit(1)
 	}
 
@@ -49,6 +50,13 @@ func main() {
 			fmt.Fprintf(os.Stderr, "health failed: %v\n", err)
 			os.Exit(1)
 		}
+	case "heartbeat":
+		code, err := runHeartbeat()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "heartbeat failed: %v\n", err)
+			os.Exit(1)
+		}
+		os.Exit(code)
 	default:
 		fmt.Fprintf(os.Stderr, "unknown command: %s\n", os.Args[1])
 		os.Exit(1)
@@ -506,6 +514,40 @@ func runHealth() error {
 		)
 	}
 	return nil
+}
+
+// runHeartbeat counts governance_events in the last 24h and pages via ntfy
+// when volume is below the configured floor. Returns the exit code: 0 if the
+// heartbeat is green, 2 if paging (so CI / cron can alert on non-zero exit).
+func runHeartbeat() (int, error) {
+	ctx := context.Background()
+	cfg, err := config.Load(configPath())
+	if err != nil {
+		return 1, fmt.Errorf("load config: %w", err)
+	}
+	if cfg.NeonDatabaseURL == "" {
+		return 1, fmt.Errorf("NEON_DATABASE_URL is required")
+	}
+	neon, err := db.NewNeonClient(ctx, cfg.NeonDatabaseURL)
+	if err != nil {
+		return 1, fmt.Errorf("connect neon: %w", err)
+	}
+	defer neon.Close()
+
+	counter := &heartbeat.PoolCounter{Pool: neon.Pool()}
+	notifier := heartbeat.NewNtfyNotifier(cfg.Heartbeat.NtfyTopic)
+
+	dec, err := heartbeat.Run(ctx, counter, notifier, cfg.Heartbeat.MinEvents24h)
+	if err != nil {
+		// If the notifier failed but we still have a decision, log and continue.
+		log.Printf("sentinel heartbeat: %v", err)
+	}
+	if dec.Paging {
+		log.Printf("sentinel heartbeat PAGE: %d events in last 24h (threshold %d)", dec.Count, dec.Threshold)
+		return 2, nil
+	}
+	log.Printf("sentinel heartbeat OK: %d events in last 24h (threshold %d)", dec.Count, dec.Threshold)
+	return 0, nil
 }
 
 // passthroughInterpreter is used when ANTHROPIC_API_KEY is not set.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	ExecutionPasses ExecutionPassesConfig `yaml:"execution_passes"`
 	Health          HealthConfig          `yaml:"health"`
 	Insights        InsightsConfig        `yaml:"insights"`
+	Heartbeat       HeartbeatConfig       `yaml:"heartbeat"`
 
 	// Environment variable overrides (not in YAML)
 	RedisURL        string `yaml:"-"`
@@ -131,6 +132,14 @@ type InsightsConfig struct {
 	ScoreDeltaThreshold  int     `yaml:"score_delta_threshold"`
 }
 
+// HeartbeatConfig controls the daily volume floor alarm.
+// When governance_events count in the last 24h falls below MinEvents24h,
+// `sentinel heartbeat` pages via ntfy. Defaults: 10 events, topic "ganglia".
+type HeartbeatConfig struct {
+	MinEvents24h int    `yaml:"min_events_24h"`
+	NtfyTopic    string `yaml:"ntfy_topic"`
+}
+
 type ChitinGovernanceConfig struct {
 	Workspaces []string `yaml:"workspaces"`
 }
@@ -184,6 +193,14 @@ func Load(path string) (*Config, error) {
 	cfg.OctiPulpoURL = os.Getenv("OCTI_PULPO_URL")
 	if cfg.OctiPulpoURL == "" {
 		cfg.OctiPulpoURL = "http://localhost:8080"
+	}
+
+	// Heartbeat defaults — see HeartbeatConfig doc.
+	if cfg.Heartbeat.MinEvents24h == 0 {
+		cfg.Heartbeat.MinEvents24h = 10
+	}
+	if cfg.Heartbeat.NtfyTopic == "" {
+		cfg.Heartbeat.NtfyTopic = "ganglia"
 	}
 
 	return &cfg, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -27,6 +27,41 @@ func TestLoadFromFile(t *testing.T) {
 	}
 }
 
+func TestLoadHeartbeatDefaults(t *testing.T) {
+	// sentinel.yaml does not set heartbeat — defaults should apply.
+	cfg, err := config.Load("../../sentinel.yaml")
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.Heartbeat.MinEvents24h != 10 {
+		t.Errorf("MinEvents24h default = %d, want 10", cfg.Heartbeat.MinEvents24h)
+	}
+	if cfg.Heartbeat.NtfyTopic != "ganglia" {
+		t.Errorf("NtfyTopic default = %q, want ganglia", cfg.Heartbeat.NtfyTopic)
+	}
+}
+
+func TestLoadHeartbeatOverrides(t *testing.T) {
+	tmp, err := os.CreateTemp(t.TempDir(), "sentinel-*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tmp.Close()
+	if _, err := tmp.WriteString("heartbeat:\n  min_events_24h: 500\n  ntfy_topic: test-topic\n"); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(tmp.Name())
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.Heartbeat.MinEvents24h != 500 {
+		t.Errorf("MinEvents24h = %d, want 500", cfg.Heartbeat.MinEvents24h)
+	}
+	if cfg.Heartbeat.NtfyTopic != "test-topic" {
+		t.Errorf("NtfyTopic = %q, want test-topic", cfg.Heartbeat.NtfyTopic)
+	}
+}
+
 func TestLoadEnvOverrides(t *testing.T) {
 	os.Setenv("NEON_DATABASE_URL", "postgres://test:5432/db")
 	defer os.Unsetenv("NEON_DATABASE_URL")

--- a/internal/heartbeat/heartbeat.go
+++ b/internal/heartbeat/heartbeat.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -50,7 +51,7 @@ type PoolCounter struct {
 func (p *PoolCounter) CountLast24h(ctx context.Context) (int, error) {
 	var count int
 	err := p.Pool.QueryRow(ctx,
-		`SELECT COUNT(*) FROM governance_events WHERE timestamp > NOW() - INTERVAL '24 hours'`,
+		`SELECT COUNT(*) FROM governance_events WHERE timestamp >= NOW() - INTERVAL '24 hours'`,
 	).Scan(&count)
 	if err != nil {
 		return 0, fmt.Errorf("count governance_events: %w", err)
@@ -72,8 +73,8 @@ func (n *NtfyNotifier) Notify(ctx context.Context, title, body, priority string)
 	if n.Topic == "" {
 		return fmt.Errorf("ntfy topic empty")
 	}
-	url := fmt.Sprintf("https://ntfy.sh/%s", n.Topic)
-	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBufferString(body))
+	endpoint := fmt.Sprintf("https://ntfy.sh/%s", url.PathEscape(n.Topic))
+	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBufferString(body))
 	if err != nil {
 		return err
 	}

--- a/internal/heartbeat/heartbeat.go
+++ b/internal/heartbeat/heartbeat.go
@@ -1,0 +1,124 @@
+// Package heartbeat implements a daily liveness alert for sentinel.
+//
+// Motivation: on 2026-04-07 our governance_events volume collapsed from
+// ~2800/day to a handful. Nobody noticed for a week because there was no
+// floor alarm. Heartbeat fixes that — it counts events in the last 24h and
+// pages via ntfy when the count drops below a configured threshold.
+package heartbeat
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Decision captures the outcome of a heartbeat check.
+type Decision struct {
+	Count     int
+	Threshold int
+	Paging    bool // true when count < threshold
+}
+
+// Decide is the pure decision function. count below threshold → page.
+func Decide(count, threshold int) Decision {
+	return Decision{
+		Count:     count,
+		Threshold: threshold,
+		Paging:    count < threshold,
+	}
+}
+
+// EventCounter abstracts the 24h count query so tests can inject fakes.
+type EventCounter interface {
+	CountLast24h(ctx context.Context) (int, error)
+}
+
+// Notifier delivers the heartbeat message somewhere (ntfy in prod).
+type Notifier interface {
+	Notify(ctx context.Context, title, body, priority string) error
+}
+
+// PoolCounter queries governance_events via a pgx pool.
+type PoolCounter struct {
+	Pool *pgxpool.Pool
+}
+
+func (p *PoolCounter) CountLast24h(ctx context.Context) (int, error) {
+	var count int
+	err := p.Pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM governance_events WHERE timestamp > NOW() - INTERVAL '24 hours'`,
+	).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("count governance_events: %w", err)
+	}
+	return count, nil
+}
+
+// NtfyNotifier posts to https://ntfy.sh/<topic>.
+type NtfyNotifier struct {
+	Topic  string
+	Client *http.Client
+}
+
+func NewNtfyNotifier(topic string) *NtfyNotifier {
+	return &NtfyNotifier{Topic: topic, Client: &http.Client{Timeout: 5 * time.Second}}
+}
+
+func (n *NtfyNotifier) Notify(ctx context.Context, title, body, priority string) error {
+	if n.Topic == "" {
+		return fmt.Errorf("ntfy topic empty")
+	}
+	url := fmt.Sprintf("https://ntfy.sh/%s", n.Topic)
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBufferString(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Title", title)
+	if priority != "" {
+		req.Header.Set("Priority", priority)
+	}
+	client := n.Client
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("ntfy status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// Run performs the heartbeat check: count → decide → notify.
+// Returns the decision so callers can set exit status.
+func Run(ctx context.Context, counter EventCounter, notifier Notifier, threshold int) (Decision, error) {
+	count, err := counter.CountLast24h(ctx)
+	if err != nil {
+		return Decision{}, err
+	}
+	dec := Decide(count, threshold)
+	var title, body, prio string
+	if dec.Paging {
+		title = "[sentinel] governance_events volume LOW"
+		body = fmt.Sprintf("Only %d events in last 24h (threshold %d). Pipeline likely broken.", dec.Count, dec.Threshold)
+		prio = "urgent"
+	} else {
+		title = "[sentinel] heartbeat OK"
+		body = fmt.Sprintf("governance_events last 24h: %d (>= %d).", dec.Count, dec.Threshold)
+		prio = "min"
+	}
+	if notifier != nil {
+		if nerr := notifier.Notify(ctx, title, body, prio); nerr != nil {
+			// Notification failure is surfaced but does not mask the decision.
+			return dec, fmt.Errorf("notify: %w", nerr)
+		}
+	}
+	return dec, nil
+}

--- a/internal/heartbeat/heartbeat_test.go
+++ b/internal/heartbeat/heartbeat_test.go
@@ -1,0 +1,111 @@
+package heartbeat
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestDecide(t *testing.T) {
+	cases := []struct {
+		name      string
+		count     int
+		threshold int
+		wantPage  bool
+	}{
+		{"below threshold pages", 2, 10, true},
+		{"zero pages", 0, 10, true},
+		{"at threshold green", 10, 10, false},
+		{"above threshold green", 2800, 10, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Decide(tc.count, tc.threshold)
+			if got.Paging != tc.wantPage {
+				t.Fatalf("Paging = %v, want %v (count=%d threshold=%d)",
+					got.Paging, tc.wantPage, tc.count, tc.threshold)
+			}
+			if got.Count != tc.count || got.Threshold != tc.threshold {
+				t.Errorf("unexpected decision echo: %+v", got)
+			}
+		})
+	}
+}
+
+type fakeCounter struct {
+	count int
+	err   error
+}
+
+func (f fakeCounter) CountLast24h(ctx context.Context) (int, error) {
+	return f.count, f.err
+}
+
+type fakeNotifier struct {
+	calls   int
+	title   string
+	body    string
+	prio    string
+	failErr error
+}
+
+func (f *fakeNotifier) Notify(ctx context.Context, title, body, priority string) error {
+	f.calls++
+	f.title = title
+	f.body = body
+	f.prio = priority
+	return f.failErr
+}
+
+func TestRun_Paging(t *testing.T) {
+	n := &fakeNotifier{}
+	dec, err := Run(context.Background(), fakeCounter{count: 3}, n, 10)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !dec.Paging {
+		t.Fatalf("expected paging decision, got %+v", dec)
+	}
+	if n.calls != 1 {
+		t.Fatalf("notifier calls = %d, want 1", n.calls)
+	}
+	if n.prio != "urgent" {
+		t.Errorf("priority = %q, want urgent", n.prio)
+	}
+}
+
+func TestRun_Green(t *testing.T) {
+	n := &fakeNotifier{}
+	dec, err := Run(context.Background(), fakeCounter{count: 2800}, n, 10)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if dec.Paging {
+		t.Fatalf("expected green decision, got %+v", dec)
+	}
+	if n.calls != 1 {
+		t.Fatalf("notifier calls = %d, want 1", n.calls)
+	}
+}
+
+func TestRun_CounterError(t *testing.T) {
+	n := &fakeNotifier{}
+	_, err := Run(context.Background(), fakeCounter{err: errors.New("db down")}, n, 10)
+	if err == nil {
+		t.Fatal("expected error on counter failure")
+	}
+	if n.calls != 0 {
+		t.Errorf("notifier should not be called on count error, calls=%d", n.calls)
+	}
+}
+
+func TestRun_NilNotifier(t *testing.T) {
+	// A nil notifier is allowed — useful for dry runs / tests.
+	dec, err := Run(context.Background(), fakeCounter{count: 0}, nil, 10)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !dec.Paging {
+		t.Fatalf("expected paging, got %+v", dec)
+	}
+}


### PR DESCRIPTION
## Summary
- \`sentinel heartbeat\` subcommand: counts governance_events in last 24h, pages ntfy if below threshold (default 10), green-pings if at/above
- Pure \`Decide(count, threshold)\` for testability; \`EventCounter\`/\`Notifier\` interfaces so tests hit no network
- Config block \`heartbeat.min_events_24h\` + \`heartbeat.ntfy_topic\` (defaults: 10, "ganglia")
- Exit codes: 0 green, 2 paging, 1 error — lets CI drive alerts

## Why P0
Our event volume collapsed 99%+ around 2026-04-07 and went unnoticed for a week. This is the alert that would've caught it in <24h (see postmortem).

## Test coverage
- Decide: below/zero/at/above
- Run paging path, green path, counter error (notifier not called), nil notifier
- Config: defaults + overrides

## Closes
- #27

## Test plan
- [x] \`go test ./...\` passes
- [x] \`go build ./...\` passes
- [ ] Wire into a cron (follow-up issue)