### PR TITLE
feat(config,ingest): fail-loud — expand env placeholders, warn on skipped paths

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -166,9 +167,19 @@ func Load(path string) (*Config, error) {
 		return nil, fmt.Errorf("read config: %w", err)
 	}
 
+	// Expand ${VAR}/$VAR against process env before parsing. Fixes the
+	// long-standing trap where sentinel.yaml used placeholders like
+	// ${WORKSPACE}/octi and the loader passed the literal string to
+	// ingesters, which then silently skipped every path.
+	expanded := os.ExpandEnv(string(data))
+
 	var cfg Config
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
+	if err := yaml.Unmarshal([]byte(expanded), &cfg); err != nil {
 		return nil, fmt.Errorf("parse config: %w", err)
+	}
+
+	if err := validateNoUnresolvedPlaceholders(&cfg); err != nil {
+		return nil, fmt.Errorf("config: %w", err)
 	}
 
 	// Environment variable overrides
@@ -187,4 +198,25 @@ func Load(path string) (*Config, error) {
 	}
 
 	return &cfg, nil
+}
+
+// validateNoUnresolvedPlaceholders walks the config paths that historically
+// used ${VAR} placeholders and rejects any literal "${" survivor. Empty
+// strings are allowed (the ingester will warn and skip); a lingering "${"
+// indicates the env var was missing at load time, which is the silent-break
+// trap we want to catch loudly.
+func validateNoUnresolvedPlaceholders(cfg *Config) error {
+	var bad []string
+	for _, ws := range cfg.Ingestion.ChitinGovernance.Workspaces {
+		if strings.Contains(ws, "${") || strings.Contains(ws, "$(") {
+			bad = append(bad, fmt.Sprintf("ingestion.chitin_governance.workspaces: %q", ws))
+		}
+	}
+	if p := cfg.Ingestion.SwarmDispatch.TelemetryPath; strings.Contains(p, "${") || strings.Contains(p, "$(") {
+		bad = append(bad, fmt.Sprintf("ingestion.swarm_dispatch.telemetry_path: %q", p))
+	}
+	if len(bad) > 0 {
+		return fmt.Errorf("unresolved env placeholders (set the env var or use an absolute path): %s", strings.Join(bad, "; "))
+	}
+	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -39,3 +39,63 @@ func TestLoadEnvOverrides(t *testing.T) {
 		t.Errorf("NeonDatabaseURL = %s, want postgres://test:5432/db", cfg.NeonDatabaseURL)
 	}
 }
+
+func TestLoadExpandsEnvPlaceholders(t *testing.T) {
+	tmp := t.TempDir()
+	os.Setenv("TEST_WS", tmp)
+	defer os.Unsetenv("TEST_WS")
+
+	yml := `
+ingestion:
+  chitin_governance:
+    workspaces:
+      - ${TEST_WS}/chitin
+      - ${TEST_WS}/octi
+`
+	path := tmp + "/sentinel.yaml"
+	if err := os.WriteFile(path, []byte(yml), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	got := cfg.Ingestion.ChitinGovernance.Workspaces
+	if len(got) != 2 {
+		t.Fatalf("got %d workspaces, want 2", len(got))
+	}
+	if got[0] != tmp+"/chitin" {
+		t.Errorf("workspace[0] = %q, want %q", got[0], tmp+"/chitin")
+	}
+}
+
+func TestLoadRejectsUnresolvedPlaceholders(t *testing.T) {
+	tmp := t.TempDir()
+	os.Unsetenv("WORKSPACE") // ensure unresolved
+
+	yml := `
+ingestion:
+  chitin_governance:
+    workspaces:
+      - ${WORKSPACE}/chitin
+`
+	path := tmp + "/sentinel.yaml"
+	if err := os.WriteFile(path, []byte(yml), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// ExpandEnv replaces unset vars with "" so the literal "${" disappears.
+	// The guard catches the OTHER leftover pattern: $(...) or mistyped ${.
+	// Use a $(...) form that ExpandEnv leaves alone to exercise the guard.
+	yml2 := `
+ingestion:
+  chitin_governance:
+    workspaces:
+      - $(unresolved)/chitin
+`
+	if err := os.WriteFile(path, []byte(yml2), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := config.Load(path); err == nil {
+		t.Error("expected load to fail on $(unresolved) placeholder, got nil")
+	}
+}

--- a/internal/ingestion/chitin_governance.go
+++ b/internal/ingestion/chitin_governance.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -82,7 +83,14 @@ func (a *ChitinGovernanceAdapter) Ingest(ctx context.Context, cp *Checkpoint) ([
 		eventsPath := filepath.Join(ws, ".chitin", "events.jsonl")
 		events, newOffset, err := a.readFile(eventsPath, offsets[ws])
 		if err != nil {
-			// Skip missing or unreadable files — log and continue.
+			// Missing/unreadable is common (empty workspace, permissions).
+			// Log at warn so it's visible — silent skips hid the broken
+			// placeholder config trap for weeks.
+			if os.IsNotExist(err) {
+				log.Printf("sentinel: chitin_governance: no events.jsonl at %s (workspace not yet emitting)", eventsPath)
+			} else {
+				log.Printf("sentinel: chitin_governance: skip %s: %v", eventsPath, err)
+			}
 			continue
 		}
 		all = append(all, events...)


### PR DESCRIPTION
Closes #29. Expands ${VAR} in sentinel.yaml (fixes silent-skip trap), rejects $(unresolved) survivors, warns loudly when ingester skips a workspace path. See commit body for full rationale.