### PR TITLE
feat(flow): events-as-health — flow.Emit + `sentinel flows` CLI

### DIFF
--- a/cmd/sentinel/flows.go
+++ b/cmd/sentinel/flows.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// runFlows reports per-flow health by rolling up governance_events rows
+// whose action starts with "flow_" (emitted by the internal/flow package).
+//
+// Output is a plain text table: flow name, last success, last failure, and a
+// verdict (OK/STALE/FAILING) derived from the two timestamps. No new schema,
+// no new dashboard — the stream is the dashboard.
+func runFlows() error {
+	ctx := context.Background()
+	url := os.Getenv("NEON_DATABASE_URL")
+	if url == "" {
+		return fmt.Errorf("NEON_DATABASE_URL is required")
+	}
+	pool, err := pgxpool.New(ctx, url)
+	if err != nil {
+		return fmt.Errorf("connect: %w", err)
+	}
+	defer pool.Close()
+
+	rows, err := pool.Query(ctx, `
+		SELECT
+		  action AS flow,
+		  MAX(CASE WHEN outcome = 'allow' THEN timestamp END) AS last_ok,
+		  MAX(CASE WHEN outcome = 'deny'  THEN timestamp END) AS last_fail,
+		  COUNT(*) FILTER (WHERE outcome = 'allow' AND timestamp > NOW() - INTERVAL '24 hours') AS ok_24h,
+		  COUNT(*) FILTER (WHERE outcome = 'deny'  AND timestamp > NOW() - INTERVAL '24 hours') AS fail_24h
+		FROM governance_events
+		WHERE event_source = 'flow'
+		GROUP BY action
+		ORDER BY action
+	`)
+	if err != nil {
+		return fmt.Errorf("query: %w", err)
+	}
+	defer rows.Close()
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "FLOW\tLAST_OK\tLAST_FAIL\tOK_24H\tFAIL_24H\tSTATUS")
+
+	flowCount := 0
+	for rows.Next() {
+		var flow string
+		var lastOK, lastFail *time.Time
+		var ok24, fail24 int
+		if err := rows.Scan(&flow, &lastOK, &lastFail, &ok24, &fail24); err != nil {
+			return fmt.Errorf("scan: %w", err)
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%d\t%s\n",
+			flow,
+			formatTs(lastOK),
+			formatTs(lastFail),
+			ok24, fail24,
+			verdict(lastOK, lastFail, ok24, fail24),
+		)
+		flowCount++
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iter: %w", err)
+	}
+
+	if flowCount == 0 {
+		fmt.Fprintln(w, "(no flow events found — call flow.Emit from your components to populate)\t\t\t\t\t")
+	}
+	return w.Flush()
+}
+
+func formatTs(t *time.Time) string {
+	if t == nil {
+		return "—"
+	}
+	return t.UTC().Format("2026-01-02 15:04Z")
+}
+
+// verdict collapses a flow's state into a single label a human can scan.
+//   OK       — at least one success in the last 24h, no more recent failure
+//   FAILING  — most recent event is a failure
+//   STALE    — never succeeded OR no activity in the last 24h
+func verdict(lastOK, lastFail *time.Time, ok24, fail24 int) string {
+	if lastFail != nil && (lastOK == nil || lastFail.After(*lastOK)) {
+		return "FAILING"
+	}
+	if ok24 == 0 && fail24 == 0 {
+		return "STALE"
+	}
+	return "OK"
+}

--- a/cmd/sentinel/main.go
+++ b/cmd/sentinel/main.go
@@ -24,11 +24,16 @@ import (
 
 func main() {
 	if len(os.Args) < 2 {
-		fmt.Fprintln(os.Stderr, "usage: sentinel <analyze|digest|ingest>")
+		fmt.Fprintln(os.Stderr, "usage: sentinel <analyze|digest|ingest|health|flows>")
 		os.Exit(1)
 	}
 
 	switch os.Args[1] {
+	case "flows":
+		if err := runFlows(); err != nil {
+			fmt.Fprintf(os.Stderr, "flows failed: %v\n", err)
+			os.Exit(1)
+		}
 	case "analyze":
 		if err := runAnalyze(); err != nil {
 			fmt.Fprintf(os.Stderr, "analyze failed: %v\n", err)

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -1,0 +1,197 @@
+// Package flow lets any chitin-ecosystem component emit start/complete/fail
+// events for a named flow (an SDLC gate, a dispatch step, a pipeline stage)
+// into the same events.jsonl stream that governance events land in. Sentinel
+// ingests them, the analyzer sees them, and `sentinel flows` rolls them up
+// into a per-flow health view.
+//
+// Events-as-health: there is no separate dashboard schema. A flow is healthy
+// when its latest `completed` is more recent than its latest `failed`, the
+// same way hotspot/toolrisk reason about governance decisions today.
+//
+// Usage:
+//
+//	flow.Emit("sentinel.analyze.pass.hotspot", "started", nil)
+//	// ... do the work ...
+//	flow.Emit("sentinel.analyze.pass.hotspot", "completed", map[string]any{
+//	    "findings": 3,
+//	})
+//
+// The wire format matches chitin's events.jsonl schema so no ingester changes
+// are needed:
+//
+//	{
+//	  "ts": "...",
+//	  "sid": "...",
+//	  "agent": "...",
+//	  "tool": "flow.<name>",     // sentinel analyzers partition on action prefix
+//	  "action": "flow_<status>", // "flow_started"|"flow_completed"|"flow_failed"
+//	  "outcome": "allow"|"deny",
+//	  "reason": "<optional>",
+//	  "source": "flow",
+//	  "latency_us": 0,
+//	  "fields": {...optional metadata...}
+//	}
+package flow
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// Status is one of the three lifecycle points of a flow.
+type Status string
+
+const (
+	Started   Status = "started"
+	Completed Status = "completed"
+	Failed    Status = "failed"
+)
+
+// event is the on-disk JSONL shape, aligned with chitin events.jsonl + mcptrace.
+type event struct {
+	Timestamp string                 `json:"ts"`
+	SessionID string                 `json:"sid,omitempty"`
+	Agent     string                 `json:"agent"`
+	Tool      string                 `json:"tool"`
+	Action    string                 `json:"action"`
+	Outcome   string                 `json:"outcome"`
+	Reason    string                 `json:"reason,omitempty"`
+	Source    string                 `json:"source"`
+	LatencyUs int64                  `json:"latency_us"`
+	Fields    map[string]any         `json:"fields,omitempty"`
+}
+
+var writeMu sync.Mutex
+
+// Emit writes a single flow lifecycle event.
+//
+// name is the dotted flow identifier, e.g. "sentinel.analyze.pass.hotspot".
+// status is Started/Completed/Failed (Completed+Failed both acceptable
+// terminal states).
+// fields is optional structured metadata persisted into the event.
+//
+// Best-effort: failures to write are swallowed so telemetry never breaks the
+// caller. Synchronous file I/O under a write mutex; expected microseconds on
+// local disk but could block under I/O contention.
+func Emit(name string, status Status, fields map[string]any) {
+	path := destination()
+	if path == "" {
+		return
+	}
+	reason := ""
+	if status == Failed {
+		if fields != nil {
+			if r, ok := fields["reason"].(string); ok {
+				reason = r
+			}
+		}
+	}
+	outcome := "allow"
+	if status == Failed {
+		outcome = "deny"
+	}
+
+	ev := event{
+		Timestamp: time.Now().UTC().Format(time.RFC3339Nano),
+		SessionID: os.Getenv("CHITIN_SESSION_ID"),
+		Agent:     agentName(),
+		Tool:      "flow." + name,
+		Action:    "flow_" + string(status),
+		Outcome:   outcome,
+		Reason:    reason,
+		Source:    "flow",
+		Fields:    fields,
+	}
+
+	data, err := json.Marshal(ev)
+	if err != nil {
+		return
+	}
+	data = append(data, '\n')
+
+	writeMu.Lock()
+	defer writeMu.Unlock()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	if _, err := f.Write(data); err != nil {
+		return
+	}
+}
+
+// Start/Complete/Fail are convenience wrappers for the common pattern
+//
+//	flow.Start(name, nil)
+//	defer flow.Complete(name, nil)
+//	// ... work ...
+//	// on error: flow.Fail(name, map[string]any{"reason": err.Error()})
+//
+// Prefer these over raw Emit for readability at the call site.
+func Start(name string, fields map[string]any) { Emit(name, Started, fields) }
+func Complete(name string, fields map[string]any) { Emit(name, Completed, fields) }
+func Fail(name string, fields map[string]any) { Emit(name, Failed, fields) }
+
+// Span runs fn bracketed by Start/Complete, or Start/Fail if fn returns a
+// non-nil error. Returns fn's error unchanged.
+//
+//	err := flow.Span("sentinel.analyze", nil, func() error {
+//	    return doAnalyze()
+//	})
+func Span(name string, fields map[string]any, fn func() error) error {
+	start := time.Now()
+	Start(name, fields)
+	err := fn()
+	elapsed := time.Since(start)
+	end := map[string]any{"duration_ms": elapsed.Milliseconds()}
+	for k, v := range fields {
+		end[k] = v
+	}
+	if err != nil {
+		end["reason"] = err.Error()
+		Fail(name, end)
+	} else {
+		Complete(name, end)
+	}
+	return err
+}
+
+// destination resolves the JSONL path to write to. Reuses the same precedence
+// the chitin hook and mcptrace emitters use so all three streams land in
+// the same file.
+func destination() string {
+	if p := os.Getenv("FLOW_EVENTS_FILE"); p != "" {
+		return p
+	}
+	if p := os.Getenv("MCPTRACE_FILE"); p != "" {
+		return p
+	}
+	if ws := os.Getenv("CHITIN_WORKSPACE"); ws != "" {
+		return filepath.Join(ws, ".chitin", "events.jsonl")
+	}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		return filepath.Join(home, ".chitin", "flow_events.jsonl")
+	}
+	return ""
+}
+
+// agentName picks a stable agent identifier for the caller. Prefers
+// explicit CHITIN_AGENT_NAME (set by chitin session wrap and by drivers),
+// falls back to a coarse runtime tag.
+func agentName() string {
+	if a := os.Getenv("CHITIN_AGENT_NAME"); a != "" {
+		return a
+	}
+	if a := os.Getenv("CHITIN_AGENT"); a != "" {
+		return a
+	}
+	return "unknown"
+}

--- a/internal/flow/flow_test.go
+++ b/internal/flow/flow_test.go
@@ -1,0 +1,135 @@
+package flow
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEmit_WritesLifecycleEvents(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "events.jsonl")
+	t.Setenv("FLOW_EVENTS_FILE", dest)
+	t.Setenv("CHITIN_SESSION_ID", "sess-1")
+	t.Setenv("CHITIN_AGENT_NAME", "test-agent")
+
+	Emit("sentinel.analyze", Started, nil)
+	Emit("sentinel.analyze", Completed, map[string]any{"findings": 3})
+	Emit("chitin.hook.pretool", Failed, map[string]any{"reason": "fail-closed"})
+
+	f, err := os.Open(dest)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+
+	var events []event
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		var ev event
+		if err := json.Unmarshal(scanner.Bytes(), &ev); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		events = append(events, ev)
+	}
+	if len(events) != 3 {
+		t.Fatalf("want 3 events, got %d", len(events))
+	}
+
+	if events[0].Tool != "flow.sentinel.analyze" || events[0].Action != "flow_started" || events[0].Outcome != "allow" {
+		t.Errorf("started event shape wrong: %+v", events[0])
+	}
+	if events[1].Action != "flow_completed" {
+		t.Errorf("completed action: got %q", events[1].Action)
+	}
+	if events[2].Action != "flow_failed" || events[2].Outcome != "deny" || events[2].Reason != "fail-closed" {
+		t.Errorf("failed event shape wrong: %+v", events[2])
+	}
+	for _, ev := range events {
+		if ev.SessionID != "sess-1" {
+			t.Errorf("session id not plumbed: %+v", ev)
+		}
+		if ev.Agent != "test-agent" {
+			t.Errorf("agent not plumbed: %+v", ev)
+		}
+		if ev.Source != "flow" {
+			t.Errorf("source should be flow: %+v", ev)
+		}
+	}
+}
+
+func TestSpan_CompletesOnNoError(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("FLOW_EVENTS_FILE", filepath.Join(dir, "events.jsonl"))
+
+	err := Span("my.flow", nil, func() error { return nil })
+	if err != nil {
+		t.Fatalf("Span returned error unexpectedly: %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(dir, "events.jsonl"))
+	if !strings.Contains(string(data), `"action":"flow_started"`) {
+		t.Error("Span should have emitted a started event")
+	}
+	if !strings.Contains(string(data), `"action":"flow_completed"`) {
+		t.Error("Span should have emitted a completed event on success")
+	}
+	if strings.Contains(string(data), `"action":"flow_failed"`) {
+		t.Error("Span should NOT emit a failed event on success")
+	}
+}
+
+func TestSpan_FailsOnError(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("FLOW_EVENTS_FILE", filepath.Join(dir, "events.jsonl"))
+
+	err := Span("my.flow", map[string]any{"context": "test"}, func() error {
+		return errors.New("kaboom")
+	})
+	if err == nil || err.Error() != "kaboom" {
+		t.Fatalf("Span should return the inner error unchanged, got %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(dir, "events.jsonl"))
+	if !strings.Contains(string(data), `"action":"flow_failed"`) {
+		t.Error("Span should emit a failed event when fn returns error")
+	}
+	if !strings.Contains(string(data), `"reason":"kaboom"`) {
+		t.Error("fail reason should be the error message")
+	}
+	// Metadata from fields should flow through to the emitted event.
+	if !strings.Contains(string(data), `"context":"test"`) {
+		t.Error("user fields should be preserved in failure emission")
+	}
+}
+
+func TestEmit_NoDestinationIsNoop(t *testing.T) {
+	t.Setenv("FLOW_EVENTS_FILE", "")
+	t.Setenv("MCPTRACE_FILE", "")
+	t.Setenv("CHITIN_WORKSPACE", "")
+	// HOME fallback may still resolve; this test just verifies no panic.
+	Emit("my.flow", Started, nil)
+}
+
+func TestDestination_Precedence(t *testing.T) {
+	t.Setenv("FLOW_EVENTS_FILE", "/tmp/flow.jsonl")
+	t.Setenv("MCPTRACE_FILE", "/tmp/mcp.jsonl")
+	t.Setenv("CHITIN_WORKSPACE", "/tmp/ws")
+	if got := destination(); got != "/tmp/flow.jsonl" {
+		t.Errorf("FLOW_EVENTS_FILE should win, got %q", got)
+	}
+
+	t.Setenv("FLOW_EVENTS_FILE", "")
+	if got := destination(); got != "/tmp/mcp.jsonl" {
+		t.Errorf("MCPTRACE_FILE should win over CHITIN_WORKSPACE, got %q", got)
+	}
+
+	t.Setenv("MCPTRACE_FILE", "")
+	if got := destination(); got != "/tmp/ws/.chitin/events.jsonl" {
+		t.Errorf("CHITIN_WORKSPACE should win over HOME, got %q", got)
+	}
+}


### PR DESCRIPTION
Partial #36. Adds `internal/flow` package + `sentinel flows` CLI for per-flow health rollup over governance_events. No new schema, no new dashboard — same stream, same ingester, same analyzer. Child issues can now instrument individual flows (chitin hook, swarm dispatch, sentinel passes, etc.) using `flow.Start/Complete/Fail/Span`.