### PR TITLE
feat(ingest): unify chitin_governance to write governance_events (closes #31)

### DIFF
--- a/cmd/sentinel/main.go
+++ b/cmd/sentinel/main.go
@@ -325,23 +325,27 @@ func runIngest() error {
 	}
 
 	// --- Chitin governance adapter ---
+	// Writes directly to governance_events (same table as sentinel-mcp's
+	// IngestFile). Previously this path wrote execution_events, which the
+	// analyzer never read. See sentinel#31.
 	if adapterFilter == "" || adapterFilter == "chitin" {
 		if len(cfg.Ingestion.ChitinGovernance.Workspaces) > 0 {
-			cgAdapter := ingestion.NewChitinGovernanceAdapter(cfg.Ingestion.ChitinGovernance.Workspaces)
+			writer := &ingestion.PgxGovernanceWriter{Pool: neon.Pool()}
+			cgAdapter := ingestion.NewChitinGovernanceAdapter(
+				cfg.Ingestion.ChitinGovernance.Workspaces,
+				cfg.Tenant.ID,
+				writer,
+			)
 			cp, _ := store.GetCheckpoint(ctx, "chitin_governance")
-			events, newCp, err := cgAdapter.Ingest(ctx, cp)
+			n, newCp, err := cgAdapter.Ingest(ctx, cp)
 			if err != nil {
 				log.Printf("sentinel: chitin_governance ingest error: %v", err)
 			} else {
-				n, err := store.Write(ctx, events)
-				if err != nil {
-					return fmt.Errorf("write chitin_governance events: %w", err)
-				}
 				if newCp != nil {
 					_ = store.SaveCheckpoint(ctx, *newCp)
 				}
 				totalIngested += n
-				log.Printf("sentinel: ingested %d events from chitin_governance", n)
+				log.Printf("sentinel: ingested %d events from chitin_governance (tenant=%s)", n, cfg.Tenant.ID)
 			}
 		}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	Health          HealthConfig          `yaml:"health"`
 	Insights        InsightsConfig        `yaml:"insights"`
 	Heartbeat       HeartbeatConfig       `yaml:"heartbeat"`
+	Tenant          TenantConfig          `yaml:"tenant"`
 
 	// Environment variable overrides (not in YAML)
 	RedisURL        string `yaml:"-"`
@@ -141,6 +142,18 @@ type HeartbeatConfig struct {
 	NtfyTopic    string `yaml:"ntfy_topic"`
 }
 
+// TenantConfig identifies which tenants.id row every ingested governance
+// event is stamped with. Required by the governance_events.tenant_id FK.
+// Override via CHITIN_TENANT_ID env var; defaults to the seeded "chitin"
+// tenant (00000000-0000-0000-0000-000000000001).
+type TenantConfig struct {
+	ID string `yaml:"id"`
+}
+
+// DefaultChitinTenantID is the UUID of the seeded "chitin" tenants row.
+// Keep in sync with the Neon tenants table seed.
+const DefaultChitinTenantID = "00000000-0000-0000-0000-000000000001"
+
 type ChitinGovernanceConfig struct {
 	Workspaces []string `yaml:"workspaces"`
 }
@@ -204,6 +217,15 @@ func Load(path string) (*Config, error) {
 	cfg.OctiPulpoURL = os.Getenv("OCTI_PULPO_URL")
 	if cfg.OctiPulpoURL == "" {
 		cfg.OctiPulpoURL = "http://localhost:8080"
+	}
+
+	// Tenant override + default. The governance_events.tenant_id column is
+	// NOT NULL with an FK to tenants.id, so we must always stamp a value.
+	if v := os.Getenv("CHITIN_TENANT_ID"); v != "" {
+		cfg.Tenant.ID = v
+	}
+	if cfg.Tenant.ID == "" {
+		cfg.Tenant.ID = DefaultChitinTenantID
 	}
 
 	// Heartbeat defaults — see HeartbeatConfig doc.

--- a/internal/ingestion/chitin_governance.go
+++ b/internal/ingestion/chitin_governance.go
@@ -11,6 +11,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // chitinEvent is the JSON shape emitted by chitin hooks (.chitin/events.jsonl).
@@ -31,16 +33,82 @@ type chitinEvent struct {
 	TrustLevel  string                 `json:"trust_level,omitempty"`
 }
 
+// GovernanceEventRow captures everything we need to persist a single
+// governance_events row. The shape mirrors the production table schema
+// (see internal/mcp/ingest.go IngestFile for the canonical INSERT) and
+// is exposed so tests can assert the writer was invoked with the right data.
+type GovernanceEventRow struct {
+	TenantID    string
+	SessionID   string
+	AgentID     string
+	EventType   string
+	Action      string
+	Resource    string
+	Outcome     string
+	RiskLevel   string
+	EventSource string
+	DriverType  string
+	Metadata    map[string]any
+	Timestamp   time.Time
+}
+
+// GovernanceWriter is the minimum surface the adapter needs from a DB.
+// Tests pass a fake; production uses pgxWriter below.
+type GovernanceWriter interface {
+	InsertGovernance(ctx context.Context, row GovernanceEventRow) error
+}
+
+// PgxGovernanceWriter wraps a pgxpool.Pool so it satisfies GovernanceWriter.
+type PgxGovernanceWriter struct {
+	Pool *pgxpool.Pool
+}
+
+func (w *PgxGovernanceWriter) InsertGovernance(ctx context.Context, row GovernanceEventRow) error {
+	md, _ := json.Marshal(row.Metadata)
+	_, err := w.Pool.Exec(ctx, `
+		INSERT INTO governance_events
+			(tenant_id, session_id, agent_id, event_type, action, resource, outcome, risk_level, event_source, driver_type, metadata, timestamp)
+		VALUES
+			($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::jsonb, $12::timestamptz)
+	`,
+		row.TenantID,
+		row.SessionID,
+		row.AgentID,
+		row.EventType,
+		row.Action,
+		row.Resource,
+		row.Outcome,
+		row.RiskLevel,
+		row.EventSource,
+		row.DriverType,
+		string(md),
+		row.Timestamp,
+	)
+	return err
+}
+
 // ChitinGovernanceAdapter reads .chitin/events.jsonl from configured workspace
-// directories and converts them to ExecutionEvents.
+// directories and writes each event directly into governance_events — the
+// same table sentinel-mcp's IngestFile targets and the only table the
+// analyzer queries. Previously this adapter wrote execution_events, which
+// the analyzer never read — a silent drop. See sentinel#31.
 type ChitinGovernanceAdapter struct {
 	workspacePaths []string
+	tenantID       string
+	writer         GovernanceWriter
 }
 
 // NewChitinGovernanceAdapter constructs a ChitinGovernanceAdapter.
 // workspacePaths are directories containing .chitin/events.jsonl files.
-func NewChitinGovernanceAdapter(workspacePaths []string) *ChitinGovernanceAdapter {
-	return &ChitinGovernanceAdapter{workspacePaths: workspacePaths}
+// tenantID is the tenants.id FK to stamp on every row (required).
+// writer handles the actual persistence; pass &PgxGovernanceWriter{Pool: pool}
+// in production or a fake in tests.
+func NewChitinGovernanceAdapter(workspacePaths []string, tenantID string, writer GovernanceWriter) *ChitinGovernanceAdapter {
+	return &ChitinGovernanceAdapter{
+		workspacePaths: workspacePaths,
+		tenantID:       tenantID,
+		writer:         writer,
+	}
 }
 
 // checkpointOffsets stores per-workspace file offsets as the checkpoint's LastRunID.
@@ -71,17 +139,26 @@ func (co checkpointOffsets) String() string {
 	return strings.Join(parts, ",")
 }
 
-// Ingest reads new governance events from all workspace paths since the checkpoint.
-func (a *ChitinGovernanceAdapter) Ingest(ctx context.Context, cp *Checkpoint) ([]ExecutionEvent, *Checkpoint, error) {
+// Ingest reads new governance events from all workspace paths since the
+// checkpoint and inserts them into governance_events via the adapter's
+// writer. Returns the number of rows written and an updated checkpoint.
+func (a *ChitinGovernanceAdapter) Ingest(ctx context.Context, cp *Checkpoint) (int, *Checkpoint, error) {
+	if a.writer == nil {
+		return 0, nil, fmt.Errorf("chitin_governance: no writer configured")
+	}
+	if a.tenantID == "" {
+		return 0, nil, fmt.Errorf("chitin_governance: tenant_id is required")
+	}
+
 	offsets := checkpointOffsets{}
 	if cp != nil {
 		offsets = parseOffsets(cp.LastRunID)
 	}
 
-	var all []ExecutionEvent
+	total := 0
 	for _, ws := range a.workspacePaths {
 		eventsPath := filepath.Join(ws, ".chitin", "events.jsonl")
-		events, newOffset, err := a.readFile(eventsPath, offsets[ws])
+		n, newOffset, err := a.ingestFile(ctx, eventsPath, offsets[ws])
 		if err != nil {
 			// Missing/unreadable is common (empty workspace, permissions).
 			// Log at warn so it's visible — silent skips hid the broken
@@ -93,7 +170,7 @@ func (a *ChitinGovernanceAdapter) Ingest(ctx context.Context, cp *Checkpoint) ([
 			}
 			continue
 		}
-		all = append(all, events...)
+		total += n
 		offsets[ws] = newOffset
 	}
 
@@ -102,27 +179,26 @@ func (a *ChitinGovernanceAdapter) Ingest(ctx context.Context, cp *Checkpoint) ([
 		LastRunID: offsets.String(),
 		LastRunAt: time.Now(),
 	}
-	return all, newCp, nil
+	return total, newCp, nil
 }
 
-func (a *ChitinGovernanceAdapter) readFile(path string, offset int64) ([]ExecutionEvent, int64, error) {
+// ingestFile reads and inserts events from a single .chitin/events.jsonl file,
+// starting at the provided byte offset. Returns the count inserted and the
+// new offset for checkpointing.
+func (a *ChitinGovernanceAdapter) ingestFile(ctx context.Context, path string, offset int64) (int, int64, error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return nil, offset, err
+		return 0, offset, err
 	}
 	defer f.Close()
 
 	if offset > 0 {
 		if _, err := f.Seek(offset, 0); err != nil {
-			return nil, offset, err
+			return 0, offset, err
 		}
 	}
 
-	// Infer repository from workspace path.
-	repo := inferRepo(path)
-
-	var events []ExecutionEvent
-	seq := 0
+	count := 0
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 256*1024), 256*1024)
 	for scanner.Scan() {
@@ -136,63 +212,77 @@ func (a *ChitinGovernanceAdapter) readFile(path string, offset int64) ([]Executi
 			continue // skip malformed lines
 		}
 
-		exitCode := 0
-		hasError := false
-		if ce.Outcome == "deny" {
-			exitCode = 2
-			hasError = true
+		row := chitinToGovernance(ce, a.tenantID)
+		if err := a.writer.InsertGovernance(ctx, row); err != nil {
+			// Return the position we stopped at so a retry resumes here.
+			pos, _ := f.Seek(0, 1)
+			return count, pos, fmt.Errorf("insert governance_events: %w", err)
 		}
-
-		durationMs := ce.LatencyUs / 1000
-
-		ev := ExecutionEvent{
-			ID:          fmt.Sprintf("cg-%s-%s-%d", ce.SID, ce.Tool, seq),
-			Timestamp:   ce.Ts,
-			Source:      SourceChitinGovernance,
-			SessionID:   ce.SID,
-			SequenceNum: seq,
-			Actor:       ActorAgent,
-			AgentID:     ce.Agent,
-			Command:     fmt.Sprintf("%s:%s", ce.Tool, ce.Action),
-			ExitCode:    &exitCode,
-			DurationMs:  &durationMs,
-			Repository:  repo,
-			HasError:    hasError,
-			Tags: map[string]string{
-				"outcome": ce.Outcome,
-				"reason":  ce.Reason,
-				"source":  ce.Source,
-				"action":  ce.Action,
-				"tool":    ce.Tool,
-			},
-		}
-		if ce.Path != "" {
-			ev.Tags["path"] = ce.Path
-		}
-		if ce.Command != "" {
-			ev.Tags["command"] = ce.Command
-		}
-		if ce.TrustScore != nil {
-			ev.Tags["trust_score"] = strconv.Itoa(*ce.TrustScore)
-		}
-		if ce.TrustLevel != "" {
-			ev.Tags["trust_level"] = ce.TrustLevel
-		}
-		events = append(events, ev)
-		seq++
+		count++
 	}
 
 	newOffset, _ := f.Seek(0, 1) // current position after scanning
-	// If scanner didn't reach EOF cleanly, use stat to get position
 	if info, err := f.Stat(); err == nil && newOffset == 0 {
 		newOffset = info.Size()
 	}
 
-	return events, newOffset, scanner.Err()
+	return count, newOffset, scanner.Err()
+}
+
+// chitinToGovernance maps a chitin hook event to a governance_events row.
+// Keep this shape aligned with internal/mcp.IngestFile — both paths must
+// produce rows the analyzer can read interchangeably.
+func chitinToGovernance(ce chitinEvent, tenantID string) GovernanceEventRow {
+	resource := ce.Path
+	if resource == "" {
+		resource = ce.Command
+	}
+
+	riskLevel := "low"
+	if ce.Outcome == "deny" {
+		riskLevel = "medium"
+		if ce.Source == "invariant" {
+			riskLevel = "high"
+		}
+	}
+
+	metadata := map[string]any{
+		"command":    ce.Command,
+		"source":     ce.Source,
+		"latency_us": ce.LatencyUs,
+		"reason":     ce.Reason,
+		"action":     ce.Action,
+		"tool":       ce.Tool,
+	}
+	if ce.TrustScore != nil {
+		metadata["trust_score"] = *ce.TrustScore
+	}
+	if ce.TrustLevel != "" {
+		metadata["trust_level"] = ce.TrustLevel
+	}
+	if ce.Path != "" {
+		metadata["path"] = ce.Path
+	}
+
+	return GovernanceEventRow{
+		TenantID:    tenantID,
+		SessionID:   ce.SID,
+		AgentID:     ce.Agent,
+		EventType:   "tool_call",
+		Action:      ce.Tool, // matches IngestFile: action = tool name
+		Resource:    resource,
+		Outcome:     ce.Outcome,
+		RiskLevel:   riskLevel,
+		EventSource: "agent",
+		DriverType:  ce.Agent,
+		Metadata:    metadata,
+		Timestamp:   ce.Ts,
+	}
 }
 
 // inferRepo attempts to extract a repo name from a file path.
 // e.g. "/path/to/sentinel/.chitin/events.jsonl" → "chitinhq/sentinel"
+// Retained for potential future use / cross-adapter consistency.
 func inferRepo(path string) string {
 	dir := filepath.Dir(filepath.Dir(path)) // strip /.chitin/events.jsonl
 	base := filepath.Base(dir)

--- a/internal/ingestion/chitin_governance_test.go
+++ b/internal/ingestion/chitin_governance_test.go
@@ -4,8 +4,29 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 )
+
+// fakeGovernanceWriter captures every row the adapter emits so tests can
+// assert on the final shape without needing a live Postgres.
+type fakeGovernanceWriter struct {
+	mu   sync.Mutex
+	rows []GovernanceEventRow
+	err  error
+}
+
+func (f *fakeGovernanceWriter) InsertGovernance(_ context.Context, row GovernanceEventRow) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.err != nil {
+		return f.err
+	}
+	f.rows = append(f.rows, row)
+	return nil
+}
+
+const testTenantID = "00000000-0000-0000-0000-000000000001"
 
 func TestChitinGovernanceAdapter_Ingest(t *testing.T) {
 	dir := t.TempDir()
@@ -18,50 +39,54 @@ func TestChitinGovernanceAdapter_Ingest(t *testing.T) {
 `
 	os.WriteFile(eventsFile, []byte(data), 0644)
 
-	adapter := NewChitinGovernanceAdapter([]string{dir})
-	events, cp, err := adapter.Ingest(context.Background(), nil)
+	w := &fakeGovernanceWriter{}
+	adapter := NewChitinGovernanceAdapter([]string{dir}, testTenantID, w)
+	n, cp, err := adapter.Ingest(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Ingest: %v", err)
 	}
-
-	if len(events) != 2 {
-		t.Fatalf("expected 2 events, got %d", len(events))
+	if n != 2 {
+		t.Fatalf("expected 2 rows inserted, got %d", n)
+	}
+	if len(w.rows) != 2 {
+		t.Fatalf("expected 2 rows captured, got %d", len(w.rows))
 	}
 
-	// First event: deny.
-	ev0 := events[0]
-	if ev0.Source != SourceChitinGovernance {
-		t.Errorf("expected source chitin_governance, got %s", ev0.Source)
+	r0 := w.rows[0]
+	if r0.TenantID != testTenantID {
+		t.Errorf("expected tenant_id propagated, got %q", r0.TenantID)
 	}
-	if !ev0.HasError {
-		t.Error("expected deny event to have has_error=true")
+	if r0.Outcome != "deny" {
+		t.Errorf("expected outcome=deny, got %q", r0.Outcome)
 	}
-	if ev0.ExitCode == nil || *ev0.ExitCode != 2 {
-		t.Errorf("expected exit_code=2 for deny, got %v", ev0.ExitCode)
+	if r0.RiskLevel != "medium" {
+		t.Errorf("expected policy-deny → medium risk, got %q", r0.RiskLevel)
 	}
-	if ev0.Command != "Bash:exec" {
-		t.Errorf("expected command 'Bash:exec', got %q", ev0.Command)
+	if r0.Action != "Bash" {
+		t.Errorf("expected action=Bash, got %q", r0.Action)
 	}
-	if ev0.Tags["outcome"] != "deny" {
-		t.Errorf("expected tag outcome=deny, got %q", ev0.Tags["outcome"])
+	if r0.Resource != "git push origin main" {
+		t.Errorf("expected resource fallback to command, got %q", r0.Resource)
 	}
-	if ev0.Tags["reason"] != "Direct push to protected branch" {
-		t.Errorf("unexpected reason tag: %q", ev0.Tags["reason"])
+	if r0.EventType != "tool_call" {
+		t.Errorf("expected event_type=tool_call, got %q", r0.EventType)
 	}
-	if ev0.AgentID != "claude-code" {
-		t.Errorf("expected agent_id claude-code, got %q", ev0.AgentID)
+	if r0.AgentID != "claude-code" {
+		t.Errorf("expected agent_id=claude-code, got %q", r0.AgentID)
+	}
+	if r0.Metadata["reason"] != "Direct push to protected branch" {
+		t.Errorf("expected reason in metadata, got %v", r0.Metadata["reason"])
 	}
 
-	// Second event: allow.
-	ev1 := events[1]
-	if ev1.HasError {
-		t.Error("expected allow event to have has_error=false")
+	r1 := w.rows[1]
+	if r1.Outcome != "allow" {
+		t.Errorf("expected outcome=allow, got %q", r1.Outcome)
 	}
-	if ev1.ExitCode == nil || *ev1.ExitCode != 0 {
-		t.Errorf("expected exit_code=0 for allow, got %v", ev1.ExitCode)
+	if r1.RiskLevel != "low" {
+		t.Errorf("expected allow → low risk, got %q", r1.RiskLevel)
 	}
-	if ev1.Command != "Read:read" {
-		t.Errorf("expected command 'Read:read', got %q", ev1.Command)
+	if r1.Resource != "src/main.go" {
+		t.Errorf("expected resource=path, got %q", r1.Resource)
 	}
 
 	// Checkpoint should be set.
@@ -72,21 +97,21 @@ func TestChitinGovernanceAdapter_Ingest(t *testing.T) {
 		t.Errorf("expected adapter chitin_governance, got %q", cp.Adapter)
 	}
 
-	// Second ingest with checkpoint should return 0 events.
-	events2, _, err := adapter.Ingest(context.Background(), cp)
+	// Second ingest with checkpoint should return 0 rows.
+	n2, _, err := adapter.Ingest(context.Background(), cp)
 	if err != nil {
 		t.Fatalf("second Ingest: %v", err)
 	}
-	if len(events2) != 0 {
-		t.Errorf("expected 0 events on re-ingest, got %d", len(events2))
+	if n2 != 0 {
+		t.Errorf("expected 0 rows on re-ingest, got %d", n2)
 	}
 }
 
 // TestChitinGovernanceAdapter_TrustTelemetry verifies that trust_score /
-// trust_level flow from chitin events into execution_events.tags. The
+// trust_level flow from chitin events into governance_events.metadata. The
 // zero-score case is important: chitin emits trust_score as *int precisely
 // so "score = 0" (lowest-trust agent) survives omitempty serialization,
-// and Sentinel must not drop that signal when forwarding to the tags map.
+// and Sentinel must not drop that signal when forwarding to metadata.
 func TestChitinGovernanceAdapter_TrustTelemetry(t *testing.T) {
 	dir := t.TempDir()
 	chitinDir := filepath.Join(dir, ".chitin")
@@ -99,36 +124,36 @@ func TestChitinGovernanceAdapter_TrustTelemetry(t *testing.T) {
 `
 	os.WriteFile(eventsFile, []byte(data), 0644)
 
-	adapter := NewChitinGovernanceAdapter([]string{dir})
-	events, _, err := adapter.Ingest(context.Background(), nil)
-	if err != nil {
+	w := &fakeGovernanceWriter{}
+	adapter := NewChitinGovernanceAdapter([]string{dir}, testTenantID, w)
+	if _, _, err := adapter.Ingest(context.Background(), nil); err != nil {
 		t.Fatalf("Ingest: %v", err)
 	}
-	if len(events) != 3 {
-		t.Fatalf("expected 3 events, got %d", len(events))
+	if len(w.rows) != 3 {
+		t.Fatalf("expected 3 rows, got %d", len(w.rows))
 	}
 
-	if got := events[0].Tags["trust_score"]; got != "500" {
-		t.Errorf("baseline trust_score tag = %q, want %q", got, "500")
+	if got := w.rows[0].Metadata["trust_score"]; got != 500 {
+		t.Errorf("baseline trust_score metadata = %v, want 500", got)
 	}
-	if got := events[0].Tags["trust_level"]; got != "baseline" {
-		t.Errorf("baseline trust_level tag = %q, want %q", got, "baseline")
+	if got := w.rows[0].Metadata["trust_level"]; got != "baseline" {
+		t.Errorf("baseline trust_level metadata = %v, want baseline", got)
 	}
 
 	// The keystone assertion: score=0 must survive.
-	if got := events[1].Tags["trust_score"]; got != "0" {
-		t.Errorf("restricted trust_score tag = %q, want %q (score=0 must be preserved)", got, "0")
+	if got := w.rows[1].Metadata["trust_score"]; got != 0 {
+		t.Errorf("restricted trust_score metadata = %v, want 0 (score=0 must be preserved)", got)
 	}
-	if got := events[1].Tags["trust_level"]; got != "restricted" {
-		t.Errorf("restricted trust_level tag = %q, want %q", got, "restricted")
+	if got := w.rows[1].Metadata["trust_level"]; got != "restricted" {
+		t.Errorf("restricted trust_level metadata = %v, want restricted", got)
 	}
 
-	// Event without trust fields must not gain empty tags.
-	if _, ok := events[2].Tags["trust_score"]; ok {
-		t.Errorf("untagged event should not have trust_score tag, got %q", events[2].Tags["trust_score"])
+	// Event without trust fields must not gain empty metadata entries.
+	if _, ok := w.rows[2].Metadata["trust_score"]; ok {
+		t.Errorf("untagged event should not have trust_score metadata")
 	}
-	if _, ok := events[2].Tags["trust_level"]; ok {
-		t.Errorf("untagged event should not have trust_level tag, got %q", events[2].Tags["trust_level"])
+	if _, ok := w.rows[2].Metadata["trust_level"]; ok {
+		t.Errorf("untagged event should not have trust_level metadata")
 	}
 }
 
@@ -146,13 +171,19 @@ func TestChitinGovernanceAdapter_IncrementalRead(t *testing.T) {
 `
 	os.WriteFile(eventsFile, []byte(initial), 0644)
 
-	adapter := NewChitinGovernanceAdapter([]string{dir})
-	events1, cp1, err := adapter.Ingest(context.Background(), nil)
+	w := &fakeGovernanceWriter{}
+	adapter := NewChitinGovernanceAdapter([]string{dir}, testTenantID, w)
+	n1, cp1, err := adapter.Ingest(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("first Ingest: %v", err)
 	}
-	if len(events1) != 3 {
-		t.Fatalf("expected 3 events, got %d", len(events1))
+	if n1 != 3 {
+		t.Fatalf("expected 3 rows, got %d", n1)
+	}
+
+	// Invariant-sourced deny should escalate to high risk.
+	if w.rows[2].RiskLevel != "high" {
+		t.Errorf("expected invariant deny → high risk, got %q", w.rows[2].RiskLevel)
 	}
 
 	// Append 2 more events.
@@ -162,15 +193,18 @@ func TestChitinGovernanceAdapter_IncrementalRead(t *testing.T) {
 `)
 	f.Close()
 
-	// Second ingest should return only the 2 new events.
-	events2, _, err := adapter.Ingest(context.Background(), cp1)
+	// Second ingest should return only the 2 new rows.
+	n2, _, err := adapter.Ingest(context.Background(), cp1)
 	if err != nil {
 		t.Fatalf("second Ingest: %v", err)
 	}
-	if len(events2) != 2 {
-		t.Errorf("expected 2 new events, got %d", len(events2))
+	if n2 != 2 {
+		t.Errorf("expected 2 new rows, got %d", n2)
 	}
-	if len(events2) > 0 && events2[0].AgentID != "copilot" {
-		t.Errorf("expected copilot agent, got %q", events2[0].AgentID)
+	if len(w.rows) != 5 {
+		t.Fatalf("expected 5 total rows captured, got %d", len(w.rows))
+	}
+	if w.rows[3].AgentID != "copilot" {
+		t.Errorf("expected copilot agent on row 4, got %q", w.rows[3].AgentID)
 	}
 }

--- a/sentinel.yaml
+++ b/sentinel.yaml
@@ -88,6 +88,12 @@ health:
   brain_health_threshold_skip: 30
   brain_health_threshold_limit: 60
 
+# Tenant scope for governance_events. tenant_id is required by the FK;
+# override with CHITIN_TENANT_ID env var if running against a non-default
+# Neon tenant. Default below is the seeded "chitin" tenant.
+tenant:
+  id: "00000000-0000-0000-0000-000000000001"
+
 execution_passes:
   command_failure:
     min_occurrences: 10


### PR DESCRIPTION
## Summary

- Redirect the `chitin_governance` ingest adapter to write directly into `governance_events` — the table sentinel-mcp's `IngestFile` already targets and the only table the analyzer reads. Closes #31.
- Drop the `store.Write` (execution_events) call for this adapter. Persistence now lives inside the adapter behind a `GovernanceWriter` interface (`PgxGovernanceWriter` in prod, fake writer in tests).
- Add `config.Tenant.ID` with `CHITIN_TENANT_ID` env override; default is the seeded "chitin" tenant UUID `00000000-0000-0000-0000-000000000001`. Required by the `governance_events.tenant_id` NOT NULL FK.

## Migration note

The `chitin_governance` adapter now writes `governance_events`, matching where sentinel-mcp's `IngestFile` has always written. The `execution_events` table is retained for GH Actions execution telemetry and brain_state (separate concern) but chitin hook events no longer land there. Any historical rows in `execution_events` that came from chitin hooks can be ignored — the analyzer never read them. Forward, all analyzer passes, sentinel-mcp ingest, and CLI `sentinel ingest --adapter=chitin` converge on one table.

No schema migrations required; the target table already exists with 377K rows of production history.

## What changed

- `internal/ingestion/chitin_governance.go` — new `GovernanceWriter` interface, `PgxGovernanceWriter` pgxpool impl, `chitinToGovernance` mapper aligned with `mcp.IngestFile`. `Ingest` returns `(int, *Checkpoint, error)`; checkpoint/offsets logic intact.
- `internal/ingestion/chitin_governance_test.go` — updated to use `fakeGovernanceWriter`; asserts tenant propagation, risk escalation (invariant deny → high), incremental read across file appends, trust telemetry including score=0 preservation.
- `internal/config/config.go` — `TenantConfig{ID}` + `DefaultChitinTenantID`, env override.
- `cmd/sentinel/main.go` — wire pool into the adapter, no longer call `store.Write` for this adapter.
- `sentinel.yaml` — new `tenant.id` block with the seeded default commented inline.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` all green
- [x] Smoke test `TestSmokePipeline` passes against Docker Postgres (pipeline produces 5 findings from seeded chitin events)
- [ ] Verify against real Neon after merge: `sentinel ingest --adapter=chitin` lands rows visible to `sentinel analyze`