### PR TITLE
fix(ingestion): map chitin ce.Source to event_source

### DIFF
--- a/cmd/sentinel/flows.go
+++ b/cmd/sentinel/flows.go
@@ -28,9 +28,10 @@ func runFlows() error {
 	}
 	defer pool.Close()
 
-	// Flow events are identified by the 'flow.' action prefix. Using action
-	// rather than event_source is durable across the ingester's current
-	// hardcoding of event_source='agent' (tracked as a separate issue).
+	// Flow events are identified by event_source. The ingester now maps
+	// chitin ce.Source correctly (issue #41), so event_source is the
+	// meaningful, indexed column to filter on. 'heartbeat' is included so
+	// driver heartbeats show up alongside flow.Emit entries.
 	rows, err := pool.Query(ctx, `
 		SELECT
 		  action AS flow,
@@ -39,7 +40,7 @@ func runFlows() error {
 		  COUNT(*) FILTER (WHERE outcome = 'allow' AND timestamp > NOW() - INTERVAL '24 hours') AS ok_24h,
 		  COUNT(*) FILTER (WHERE outcome = 'deny'  AND timestamp > NOW() - INTERVAL '24 hours') AS fail_24h
 		FROM governance_events
-		WHERE action LIKE 'flow.%'
+		WHERE event_source IN ('flow', 'heartbeat')
 		GROUP BY action
 		ORDER BY action
 	`)

--- a/internal/ingestion/chitin_governance.go
+++ b/internal/ingestion/chitin_governance.go
@@ -273,10 +273,34 @@ func chitinToGovernance(ce chitinEvent, tenantID string) GovernanceEventRow {
 		Resource:    resource,
 		Outcome:     ce.Outcome,
 		RiskLevel:   riskLevel,
-		EventSource: "agent",
+		EventSource: mapChitinSourceToEventSource(ce.Source),
 		DriverType:  ce.Agent,
 		Metadata:    metadata,
 		Timestamp:   ce.Ts,
+	}
+}
+
+// mapChitinSourceToEventSource maps the ce.Source field from a chitin hook
+// event to the governance_events.event_source column. See issue #41.
+//
+//	"flow"                                    -> "flow"       (from flow.Emit)
+//	"heartbeat"                               -> "heartbeat"  (from chitin driver heartbeat)
+//	"policy"|"invariant"|"fail-open"|
+//	  "fail-closed"                           -> "agent"      (governance decisions)
+//	"octi"|"atlas"                            -> "mcp_server" (from mcptrace)
+//	anything else                             -> "agent"      (safe default)
+func mapChitinSourceToEventSource(src string) string {
+	switch src {
+	case "flow":
+		return "flow"
+	case "heartbeat":
+		return "heartbeat"
+	case "policy", "invariant", "fail-open", "fail-closed":
+		return "agent"
+	case "octi", "atlas":
+		return "mcp_server"
+	default:
+		return "agent"
 	}
 }
 

--- a/internal/ingestion/chitin_governance_test.go
+++ b/internal/ingestion/chitin_governance_test.go
@@ -208,3 +208,59 @@ func TestChitinGovernanceAdapter_IncrementalRead(t *testing.T) {
 		t.Errorf("expected copilot agent on row 4, got %q", w.rows[3].AgentID)
 	}
 }
+
+// TestMapChitinSourceToEventSource locks in the ce.Source -> event_source
+// mapping documented on issue #41. A regression here will silently re-break
+// downstream filters (e.g. `sentinel flows` uses event_source IN (...)).
+func TestMapChitinSourceToEventSource(t *testing.T) {
+	cases := []struct {
+		source string
+		want   string
+	}{
+		{"flow", "flow"},
+		{"heartbeat", "heartbeat"},
+		{"policy", "agent"},
+		{"invariant", "agent"},
+		{"fail-open", "agent"},
+		{"fail-closed", "agent"},
+		{"octi", "mcp_server"},
+		{"atlas", "mcp_server"},
+		{"", "agent"},
+		{"something-unknown", "agent"},
+	}
+	for _, tc := range cases {
+		got := mapChitinSourceToEventSource(tc.source)
+		if got != tc.want {
+			t.Errorf("mapChitinSourceToEventSource(%q) = %q, want %q", tc.source, got, tc.want)
+		}
+	}
+}
+
+// TestChitinToGovernance_EventSourceMapping asserts the full row builder
+// carries ce.Source through to the row's EventSource column.
+func TestChitinToGovernance_EventSourceMapping(t *testing.T) {
+	cases := map[string]string{
+		"flow":        "flow",
+		"heartbeat":   "heartbeat",
+		"policy":      "agent",
+		"invariant":   "agent",
+		"fail-open":   "agent",
+		"fail-closed": "agent",
+		"octi":        "mcp_server",
+		"atlas":       "mcp_server",
+		"mystery":     "agent",
+	}
+	for src, want := range cases {
+		ce := chitinEvent{
+			SID:     "sess-x",
+			Agent:   "claude-code",
+			Tool:    "Bash",
+			Outcome: "allow",
+			Source:  src,
+		}
+		row := chitinToGovernance(ce, testTenantID)
+		if row.EventSource != want {
+			t.Errorf("source %q: EventSource = %q, want %q", src, row.EventSource, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes #41.

- `chitinToGovernance` in `internal/ingestion/chitin_governance.go` was hardcoding `EventSource: "agent"` for every row, losing the incoming `ce.Source` field. Introduced `mapChitinSourceToEventSource` with the documented mapping:
  - `flow` -> `flow`
  - `heartbeat` -> `heartbeat`
  - `policy | invariant | fail-open | fail-closed` -> `agent`
  - `octi | atlas` -> `mcp_server`
  - anything else -> `agent` (safe default)
- Swapped the `sentinel flows` WHERE clause in `cmd/sentinel/flows.go` from the `action LIKE 'flow.%'` workaround (PR #40) to the now-meaningful indexed column `event_source IN ('flow','heartbeat')`. Comment updated to match.
- No schema changes. Existing rows are untouched; future rows carry the correct source.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] New `TestMapChitinSourceToEventSource` covers every documented source plus unknown/empty fallbacks
- [x] New `TestChitinToGovernance_EventSourceMapping` asserts the full row builder propagates ce.Source
- [ ] Non-regression: `sentinel flows` still lists flow rows against live Neon (deferred to post-merge; tests are unit-only per issue guidance)

Only caller of `chitinToGovernance` is the adapter's `Ingest` loop; no other call sites needed changes.

Generated with Claude Code