### PR TITLE
feat(cli): emit driver.sentinel.heartbeat on every invocation

### DIFF
--- a/cmd/sentinel/main.go
+++ b/cmd/sentinel/main.go
@@ -24,11 +24,37 @@ import (
 	"github.com/chitinhq/sentinel/internal/router"
 )
 
+// sentinelStartTime is the process start time for self-heartbeat uptime.
+var sentinelStartTime = time.Now()
+
+// sentinelVersion is a compile-time version string (set via -ldflags), falling
+// back to "dev" when unset.
+var sentinelVersion = "dev"
+
+// emitSelfHeartbeat emits a driver.sentinel.heartbeat flow event so the
+// fleet-health view (chitinhq/sentinel#43 `sentinel drivers`) knows when
+// sentinel last ran. Best-effort; flow.Emit swallows I/O errors.
+func emitSelfHeartbeat(subcommand string) {
+	host, err := os.Hostname()
+	if err != nil || host == "" {
+		host = "unknown"
+	}
+	flow.Emit("driver.sentinel.heartbeat", flow.Completed, map[string]any{
+		"subcommand":     subcommand,
+		"host":           host,
+		"pid":            os.Getpid(),
+		"uptime_seconds": time.Since(sentinelStartTime).Seconds(),
+		"version":        sentinelVersion,
+	})
+}
+
 func main() {
 	if len(os.Args) < 2 {
 		fmt.Fprintln(os.Stderr, "usage: sentinel <analyze|digest|ingest|health|heartbeat|flows>")
 		os.Exit(1)
 	}
+
+	emitSelfHeartbeat(os.Args[1])
 
 	switch os.Args[1] {
 	case "flows":


### PR DESCRIPTION
Partial sentinel#43 — sentinel emits self-heartbeat on every CLI invocation.

## Summary
- main.go now calls emitSelfHeartbeat(subcommand) before the dispatch switch, so every \`sentinel analyze|ingest|heartbeat|flows|digest|health\` run lands a \`flow.driver.sentinel.heartbeat\` event in events.jsonl.
- Lets \`sentinel drivers\` show \"sentinel last ran Nmin ago\" despite sentinel being a CLI, not a daemon.
- Uses internal/flow directly. Best-effort — never breaks the caller.

## Sample event
\`\`\`json
{
  \"tool\": \"flow.driver.sentinel.heartbeat\",
  \"action\": \"flow_completed\",
  \"fields\": {
    \"subcommand\": \"analyze\",
    \"host\": \"harbor\",
    \"pid\": 54321,
    \"uptime_seconds\": 0.002,
    \"version\": \"dev\"
  }
}
\`\`\`

## Test plan
- [x] go build ./...
- [x] go test ./...