### PR TITLE
feat(analyzer): unacked dispatch detector (pass 8)

### DIFF
--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -166,6 +166,21 @@ func (a *Analyzer) Run(ctx context.Context) ([]Finding, error) {
 			})
 		}
 
+		// Pass 8: Unacked dispatch — flow.X.started with no matching
+		// .completed/.failed within TTL. Catches dispatch-to-dead-target.
+		_ = flow.Span("sentinel.analyze.pass.unacked", nil, func() error {
+			events, qerr := a.store.QueryEvents(ctx, since, now)
+			if qerr != nil {
+				log.Printf("sentinel: pass 8 (unacked): %v", qerr)
+				return qerr
+			}
+			unacked := DetectUnacked(events, a.cfg.Detection.Unacked.TTL)
+			log.Printf("sentinel: pass 8 (unacked) found %d findings", len(unacked))
+			all = append(all, unacked...)
+			flow.Complete("sentinel.analyze.pass.unacked.findings", map[string]any{"findings": len(unacked)})
+			return nil
+		})
+
 		log.Printf("sentinel: total findings: %d", len(all))
 		return nil
 	})

--- a/internal/analyzer/unacked.go
+++ b/internal/analyzer/unacked.go
@@ -1,0 +1,157 @@
+package analyzer
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// lifecycleStatus is one of "started", "completed", "failed", or "" if the
+// event doesn't participate in a flow lifecycle.
+type lifecycleStatus string
+
+const (
+	lifecycleStarted   lifecycleStatus = "started"
+	lifecycleCompleted lifecycleStatus = "completed"
+	lifecycleFailed    lifecycleStatus = "failed"
+)
+
+// flowLifecycle extracts (base flow name, status) from an event. It supports
+// two on-wire conventions so the pass works regardless of which emitter fed
+// the pipeline:
+//
+//  1. Dotted-suffix form: Action = "flow.<name>.started"/".completed"/".failed".
+//     Strip the trailing suffix; the base is everything before.
+//  2. Chitin hook form (see internal/flow/flow.go + ingestion/chitin_governance.go):
+//     Action = "flow.<name>" (the tool), and Metadata["action"] =
+//     "flow_started"/"flow_completed"/"flow_failed".
+//
+// Returns ("", "") if the event is not a flow lifecycle event.
+func flowLifecycle(e Event) (string, lifecycleStatus) {
+	// Form (1): dotted suffix on Action itself.
+	if strings.HasSuffix(e.Action, ".started") {
+		return strings.TrimSuffix(e.Action, ".started"), lifecycleStarted
+	}
+	if strings.HasSuffix(e.Action, ".completed") {
+		return strings.TrimSuffix(e.Action, ".completed"), lifecycleCompleted
+	}
+	if strings.HasSuffix(e.Action, ".failed") {
+		return strings.TrimSuffix(e.Action, ".failed"), lifecycleFailed
+	}
+
+	// Form (2): chitin hook / flow.Emit schema. Tool is the base name
+	// (carried through Action), lifecycle lives in metadata["action"].
+	if !strings.HasPrefix(e.Action, "flow.") {
+		return "", ""
+	}
+	if e.Metadata == nil {
+		return "", ""
+	}
+	meta, _ := e.Metadata["action"].(string)
+	switch meta {
+	case "flow_started":
+		return e.Action, lifecycleStarted
+	case "flow_completed":
+		return e.Action, lifecycleCompleted
+	case "flow_failed":
+		return e.Action, lifecycleFailed
+	}
+	return "", ""
+}
+
+// DetectUnacked finds flow.X.started events with no matching .completed or
+// .failed within TTL. Pattern catches dispatch-to-dead-target: caller
+// reported success at boundary N without receipt from boundary N+1.
+//
+// Algorithm:
+//  1. Bucket events by (base flow name, session_id).
+//  2. Walk each bucket in timestamp order tracking a FIFO of open starts.
+//  3. A completed/failed closes the oldest open start for that bucket.
+//  4. Starts still open at end of input whose age > ttl become a finding.
+//  5. One Finding per (flow_base, session_id), carrying the unacked count
+//     and the oldest unacked start as evidence.
+func DetectUnacked(events []Event, ttl time.Duration) []Finding {
+	type key struct {
+		flowBase  string
+		sessionID string
+	}
+
+	buckets := make(map[key][]Event)
+	for _, e := range events {
+		base, status := flowLifecycle(e)
+		if base == "" || status == "" {
+			continue
+		}
+		k := key{flowBase: base, sessionID: e.SessionID}
+		buckets[k] = append(buckets[k], e)
+	}
+
+	now := time.Now()
+	var findings []Finding
+
+	for k, bucket := range buckets {
+		sort.Slice(bucket, func(i, j int) bool {
+			return bucket[i].Timestamp.Before(bucket[j].Timestamp)
+		})
+
+		// FIFO of open starts. We use a slice as a queue.
+		var open []Event
+		for _, ev := range bucket {
+			_, status := flowLifecycle(ev)
+			switch status {
+			case lifecycleStarted:
+				open = append(open, ev)
+			case lifecycleCompleted, lifecycleFailed:
+				if len(open) > 0 {
+					open = open[1:]
+				}
+				// If there are no opens, this ack has no matching start —
+				// ignore it. Pre-window or duplicate acks are not findings.
+			}
+		}
+
+		// Filter to opens whose age exceeds ttl.
+		var stale []Event
+		for _, s := range open {
+			if now.Sub(s.Timestamp) > ttl {
+				stale = append(stale, s)
+			}
+		}
+		if len(stale) == 0 {
+			continue
+		}
+
+		// Evidence: oldest unacked first (capped at 10).
+		evidence := stale
+		if len(evidence) > 10 {
+			evidence = evidence[:10]
+		}
+		oldest := stale[0].Timestamp
+
+		findings = append(findings, Finding{
+			ID:       fmt.Sprintf("unacked-%s-%s-%d", k.flowBase, k.sessionID, oldest.Unix()),
+			Pass:     "unacked",
+			PolicyID: k.flowBase,
+			Metrics: Metrics{
+				Count:      len(stale),
+				SampleSize: len(bucket),
+			},
+			Evidence:   evidence,
+			DetectedAt: now,
+		})
+	}
+
+	// Deterministic ordering: highest unacked count first, tie-break on key.
+	sort.Slice(findings, func(i, j int) bool {
+		if findings[i].Metrics.Count != findings[j].Metrics.Count {
+			return findings[i].Metrics.Count > findings[j].Metrics.Count
+		}
+		if findings[i].PolicyID != findings[j].PolicyID {
+			return findings[i].PolicyID < findings[j].PolicyID
+		}
+		return findings[i].ID < findings[j].ID
+	})
+
+	return findings
+}

--- a/internal/analyzer/unacked_test.go
+++ b/internal/analyzer/unacked_test.go
@@ -1,0 +1,161 @@
+package analyzer_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/chitinhq/sentinel/internal/analyzer"
+)
+
+// mkStart/mkComplete/mkFail build dotted-suffix flow events at age seconds
+// ago. We use the dotted-suffix form in most tests because it keeps the
+// fixtures short; see TestUnacked_HookSchema for the metadata form.
+func mkEvent(flow, suffix, session string, ageSec int) analyzer.Event {
+	return analyzer.Event{
+		Action:    flow + suffix,
+		SessionID: session,
+		Timestamp: time.Now().Add(-time.Duration(ageSec) * time.Second),
+	}
+}
+
+func TestUnacked_MatchedPair_NoFinding(t *testing.T) {
+	events := []analyzer.Event{
+		mkEvent("flow.dispatch", ".started", "s1", 300),
+		mkEvent("flow.dispatch", ".completed", "s1", 290),
+	}
+	findings := analyzer.DetectUnacked(events, 60*time.Second)
+	if len(findings) != 0 {
+		t.Fatalf("matched pair: want 0 findings, got %d", len(findings))
+	}
+}
+
+func TestUnacked_MatchedPair_Failed_NoFinding(t *testing.T) {
+	events := []analyzer.Event{
+		mkEvent("flow.dispatch", ".started", "s1", 300),
+		mkEvent("flow.dispatch", ".failed", "s1", 290),
+	}
+	findings := analyzer.DetectUnacked(events, 60*time.Second)
+	if len(findings) != 0 {
+		t.Fatalf("failed-ack: want 0 findings, got %d", len(findings))
+	}
+}
+
+func TestUnacked_PastTTL_Finding(t *testing.T) {
+	events := []analyzer.Event{
+		mkEvent("flow.dispatch", ".started", "s1", 300),
+	}
+	findings := analyzer.DetectUnacked(events, 60*time.Second)
+	if len(findings) != 1 {
+		t.Fatalf("want 1 finding, got %d", len(findings))
+	}
+	if findings[0].Metrics.Count != 1 {
+		t.Errorf("want count=1, got %d", findings[0].Metrics.Count)
+	}
+	if findings[0].PolicyID != "flow.dispatch" {
+		t.Errorf("want PolicyID=flow.dispatch, got %q", findings[0].PolicyID)
+	}
+	if findings[0].Pass != "unacked" {
+		t.Errorf("want Pass=unacked, got %q", findings[0].Pass)
+	}
+	if len(findings[0].Evidence) != 1 {
+		t.Errorf("want 1 evidence row, got %d", len(findings[0].Evidence))
+	}
+}
+
+func TestUnacked_WithinTTL_NoFinding(t *testing.T) {
+	events := []analyzer.Event{
+		mkEvent("flow.dispatch", ".started", "s1", 10),
+	}
+	findings := analyzer.DetectUnacked(events, 60*time.Second)
+	if len(findings) != 0 {
+		t.Fatalf("live start within TTL: want 0 findings, got %d", len(findings))
+	}
+}
+
+func TestUnacked_CrossSession_NotMatched(t *testing.T) {
+	// Session A starts, Session B "completes" — these must NOT cancel out.
+	events := []analyzer.Event{
+		mkEvent("flow.dispatch", ".started", "sA", 300),
+		mkEvent("flow.dispatch", ".completed", "sB", 290),
+	}
+	findings := analyzer.DetectUnacked(events, 60*time.Second)
+	// sA has an unacked start. sB has a stray completed with no open — ignored.
+	if len(findings) != 1 {
+		t.Fatalf("want 1 finding, got %d", len(findings))
+	}
+	if findings[0].PolicyID != "flow.dispatch" {
+		t.Errorf("PolicyID = %q", findings[0].PolicyID)
+	}
+}
+
+func TestUnacked_CrossSession_BothUnacked(t *testing.T) {
+	events := []analyzer.Event{
+		mkEvent("flow.dispatch", ".started", "sA", 300),
+		mkEvent("flow.dispatch", ".started", "sB", 290),
+	}
+	findings := analyzer.DetectUnacked(events, 60*time.Second)
+	if len(findings) != 2 {
+		t.Fatalf("want 2 findings (one per session), got %d", len(findings))
+	}
+}
+
+func TestUnacked_Interleaved_MultipleFlows(t *testing.T) {
+	events := []analyzer.Event{
+		mkEvent("flow.a", ".started", "s1", 300),
+		mkEvent("flow.b", ".started", "s1", 300),
+		mkEvent("flow.a", ".completed", "s1", 290),
+		// flow.b left unacked, past TTL
+	}
+	findings := analyzer.DetectUnacked(events, 60*time.Second)
+	if len(findings) != 1 {
+		t.Fatalf("want 1 finding (flow.b only), got %d", len(findings))
+	}
+	if findings[0].PolicyID != "flow.b" {
+		t.Errorf("PolicyID = %q, want flow.b", findings[0].PolicyID)
+	}
+}
+
+func TestUnacked_Empty(t *testing.T) {
+	findings := analyzer.DetectUnacked(nil, 60*time.Second)
+	if len(findings) != 0 {
+		t.Fatalf("empty input: want 0, got %d", len(findings))
+	}
+}
+
+func TestUnacked_MoreStartsThanCompletes(t *testing.T) {
+	// 3 starts, 1 complete → 2 unacked for the same (flow, session).
+	events := []analyzer.Event{
+		mkEvent("flow.x", ".started", "s1", 300),
+		mkEvent("flow.x", ".started", "s1", 280),
+		mkEvent("flow.x", ".started", "s1", 260),
+		mkEvent("flow.x", ".completed", "s1", 250),
+	}
+	findings := analyzer.DetectUnacked(events, 60*time.Second)
+	if len(findings) != 1 {
+		t.Fatalf("want 1 finding, got %d", len(findings))
+	}
+	if findings[0].Metrics.Count != 2 {
+		t.Errorf("unacked count = %d, want 2", findings[0].Metrics.Count)
+	}
+}
+
+func TestUnacked_HookSchema(t *testing.T) {
+	// Chitin hook / flow.Emit form: Action = "flow.<name>", lifecycle in
+	// metadata["action"] = "flow_started"/"flow_completed"/"flow_failed".
+	now := time.Now()
+	events := []analyzer.Event{
+		{
+			Action:    "flow.dispatch",
+			SessionID: "s1",
+			Timestamp: now.Add(-300 * time.Second),
+			Metadata:  map[string]any{"action": "flow_started"},
+		},
+	}
+	findings := analyzer.DetectUnacked(events, 60*time.Second)
+	if len(findings) != 1 {
+		t.Fatalf("hook schema: want 1 finding, got %d", len(findings))
+	}
+	if findings[0].PolicyID != "flow.dispatch" {
+		t.Errorf("PolicyID = %q, want flow.dispatch", findings[0].PolicyID)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,6 +43,14 @@ type DetectionConfig struct {
 	FalsePositive FalsePositiveConfig `yaml:"false_positive"`
 	Bypass        BypassConfig        `yaml:"bypass"`
 	Anomaly       AnomalyConfig       `yaml:"anomaly"`
+	Unacked       UnackedConfig       `yaml:"unacked"`
+}
+
+// UnackedConfig controls the dispatch-to-dead-target detector: a flow.X.started
+// event with no matching .completed or .failed within TTL indicates the caller
+// reported success at boundary N without receipt from boundary N+1.
+type UnackedConfig struct {
+	TTL time.Duration `yaml:"ttl"`
 }
 
 type FalsePositiveConfig struct {
@@ -238,6 +246,12 @@ func Load(path string) (*Config, error) {
 	}
 	if cfg.Tenant.ID == "" {
 		cfg.Tenant.ID = DefaultChitinTenantID
+	}
+
+	// Unacked detector default: 60s TTL. Longer than most flow durations
+	// but short enough that dispatch-to-dead-target surfaces within a run.
+	if cfg.Detection.Unacked.TTL == 0 {
+		cfg.Detection.Unacked.TTL = 60 * time.Second
 	}
 
 	// Heartbeat defaults — see HeartbeatConfig doc.


### PR DESCRIPTION
Closes #47.

## Summary

New analyzer pass that detects **dispatch-to-dead-target**: a `flow.X.started` event with no matching `.completed` or `.failed` within TTL. This catches the autoimmune failure class where a caller claims success at boundary N without receipt from boundary N+1 — the layer above thinks it dispatched, the layer below never ran.

## Algorithm

1. Bucket events by `(flow_base, session_id)`.
2. Walk each bucket in timestamp order with a FIFO of open starts.
3. A `.completed` or `.failed` closes the oldest open start for that bucket. Stray acks (no open start) are ignored.
4. After the walk, any still-open start older than `ttl` contributes to a finding.
5. One `Finding` per bucket: `Metrics.Count` = number of stale unacked starts, `Evidence[0]` = oldest unacked start.

## Event schema note

The spec asked me to double-check which field carries the flow name. Per `internal/flow/flow.go` + `internal/ingestion/chitin_governance.go`, flow lifecycle events on the wire look like:

- `Action` = `"flow.<name>"` (e.g. `flow.sentinel.analyze.pass.hotspot`)
- `Metadata["action"]` = `"flow_started"` | `"flow_completed"` | `"flow_failed"`

The detector supports both this hook form **and** a dotted-suffix form (`Action="flow.x.started"`) so it works regardless of which emitter fed the pipeline. See `flowLifecycle()` in `unacked.go`.

## Worked example

Given events (TTL=60s, now=T):

| ts | action | session | metadata.action |
|----|--------|---------|-----------------|
| T-300s | `flow.dispatch.anthropic` | `sess-A` | `flow_started` |
| T-290s | `flow.dispatch.anthropic` | `sess-A` | `flow_started` |
| T-280s | `flow.dispatch.anthropic` | `sess-A` | `flow_completed` |

Result:
\`\`\`
Finding{
  ID:       \"unacked-flow.dispatch.anthropic-sess-A-<T-290>\",
  Pass:     \"unacked\",
  PolicyID: \"flow.dispatch.anthropic\",
  Metrics:  {Count: 1, SampleSize: 3},
  Evidence: [<the T-290 started event>],
}
\`\`\`

Reads as: \"In session sess-A, flow.dispatch.anthropic had 1 start that never completed (oldest: 290s ago).\"

## Test plan

- [x] Matched start+complete within TTL → no finding
- [x] Matched start+fail → no finding
- [x] Unacked past TTL → 1 finding, count=1
- [x] Live start within TTL → no finding
- [x] Session A start + session B completed → 1 finding (cross-session doesn't cancel)
- [x] Two unacked starts in two sessions → 2 findings
- [x] Interleaved flow.a (acked) and flow.b (unacked) → 1 finding for flow.b only
- [x] Empty input → empty findings
- [x] N starts + M completes (N>M) → 1 finding with count=N-M
- [x] Chitin hook schema (metadata.action=flow_started) form
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` green across all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)