### PR TITLE
rename: hunt_session → quest_session (workspace#382)

### DIFF
--- a/migrations/004_quest_session.sql
+++ b/migrations/004_quest_session.sql
@@ -1,11 +1,12 @@
--- 004_hunt_session.sql
--- Hunt MVP — one row per /go session, rendered to public HTML by chitinhq/hunt.
+-- 004_quest_session.sql
+-- Quest MVP — one row per /go session, rendered to public HTML by chitinhq/quest.
 -- Spec: workspace:docs/superpowers/specs/2026-04-13-hunt-mvp-design.md
 -- Boundary: workspace:docs/strategy/soulforge-hunt-boundary-2026-04-13.md
 --   party[].soul lives here (DB is private). The renderer strips it before
 --   committing to gh-pages; only party[].class reaches public HTML.
+-- Renamed from hunt_session under workspace#382.
 
-CREATE TABLE IF NOT EXISTS hunt_session (
+CREATE TABLE IF NOT EXISTS quest_session (
   session_id    TEXT PRIMARY KEY,
   started_at    TIMESTAMPTZ NOT NULL,
   ended_at      TIMESTAMPTZ,
@@ -13,8 +14,8 @@ CREATE TABLE IF NOT EXISTS hunt_session (
   party_name    TEXT NOT NULL,
   encounter     TEXT NOT NULL,
   party         JSONB NOT NULL,
-  quarry        JSONB NOT NULL DEFAULT '[]',
-  drops         JSONB NOT NULL DEFAULT '[]',
+  objective     JSONB NOT NULL DEFAULT '[]',
+  loot          JSONB NOT NULL DEFAULT '[]',
   moves         JSONB NOT NULL DEFAULT '[]',
   xp_awarded    INT NOT NULL DEFAULT 0,
   headline      TEXT,
@@ -26,5 +27,5 @@ CREATE TABLE IF NOT EXISTS hunt_session (
   updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
-CREATE INDEX IF NOT EXISTS hunt_session_ended_idx ON hunt_session (ended_at DESC);
-CREATE INDEX IF NOT EXISTS hunt_session_party_idx ON hunt_session (party_name);
+CREATE INDEX IF NOT EXISTS quest_session_ended_idx ON quest_session (ended_at DESC);
+CREATE INDEX IF NOT EXISTS quest_session_party_idx ON quest_session (party_name);

--- a/scripts/orphan_emitters.sql
+++ b/scripts/orphan_emitters.sql
@@ -73,12 +73,12 @@ LEFT JOIN governance_events e
 GROUP BY p.label ORDER BY hits DESC;
 
 \echo
-\echo --- 4. hunt_session — does hunt XP actually persist? ---
+\echo --- 4. quest_session — does hunt XP actually persist? ---
 SELECT count(*)                                    AS total_sessions,
        count(*) FILTER (WHERE xp_awarded > 0)      AS sessions_with_xp,
        max(started_at)                             AS last_started,
        max(ended_at)                               AS last_ended
-FROM hunt_session;
+FROM quest_session;
 
 \echo
 \echo --- 5. reader check: insights referencing orphan terms ---
@@ -99,7 +99,7 @@ SELECT conname,
        confrelid::regclass AS to_table
 FROM pg_constraint
 WHERE contype = 'f'
-  AND confrelid::regclass::text IN ('execution_events','hunt_session','governance_events');
+  AND confrelid::regclass::text IN ('execution_events','quest_session','governance_events');
 
 \echo
 \echo --- 8. sample of orphan governance rows (last 25) ---


### PR DESCRIPTION
## Summary

Sentinel side of the hunt→quest rename. The Neon DDL has already been executed against prod (0 rows, safe).

- Renames migration file `004_hunt_session.sql` → `004_quest_session.sql`
- Updates DDL: table, columns (`quarry`→`objective`, `drops`→`loot`), indexes
- Updates `scripts/orphan_emitters.sql` references to the new table name

## Not changed

- `CHITIN_HUNT_*` env vars: **grep returned none in sentinel code** (the emitter was living in the `/hunt` skill, not in sentinel Go/Python). No code changes needed on this surface.
- `governance_analysis.sql` line 120: `('hunt', 'hunt')` is a historical event-name search pattern over `execution_events`, not a live identifier — left as-is.

## Test plan

- [x] Neon DDL executed against prod, `\d quest_session` verified
- [ ] Confirm next sentinel ingest cycle still reads `execution_events` unchanged (this rename doesn't touch that path)

Refs: https://github.com/chitinhq/workspace/issues/382
Paired PR: https://github.com/chitinhq/quest/pull/4

🤖 Generated with [Claude Code](https://claude.com/claude-code)