### PR TITLE
feat(quest): Phase 4 scaffolding migrations (soul_scorecard + campaign_achievements)

### DIFF
--- a/migrations/007_soul_scorecard.sql
+++ b/migrations/007_soul_scorecard.sql
@@ -1,0 +1,30 @@
+-- 007_soul_scorecard.sql
+-- Phase 4 scaffolding: multi-session soul progression.
+-- Spec: workspace:docs/strategy/quest-campaign-charter-2026-04-14.md (Phase 4)
+--
+-- Per jokic's governance rule "count assists, not points," each closed session
+-- records which souls led vs. shipped-in-support. Aggregated across sessions,
+-- this reveals each soul's real-world impact — the scoreboard the game is
+-- actually keeping.
+--
+-- This migration is SCAFFOLDING. No automatic behavior activates; it only
+-- gives scripts/soul-scorecard-sync.sh a place to write. Interlock mechanics
+-- (Phase 4 proper) read from here once data accumulates.
+--
+-- Additive. IF NOT EXISTS throughout.
+
+CREATE TABLE IF NOT EXISTS soul_scorecard (
+  soul            TEXT NOT NULL,
+  metric_name     TEXT NOT NULL,   -- e.g. 'sessions_led', 'sessions_shipped_in',
+                                   -- 'sessions_grey', 'vetoes_called', 'slices_dropped'
+  metric_value    INTEGER NOT NULL DEFAULT 0,
+  last_session_id TEXT,
+  last_event_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (soul, metric_name)
+);
+
+CREATE INDEX IF NOT EXISTS soul_scorecard_last_event_idx
+  ON soul_scorecard(last_event_at DESC);
+
+COMMENT ON TABLE soul_scorecard IS
+  'Phase 4 scaffolding. Per-(soul, metric) tallies aggregated from quest_session.party + status. Written by scripts/soul-scorecard-sync.sh. Read by future Phase 4 interlock logic.';

--- a/migrations/008_campaign_achievements.sql
+++ b/migrations/008_campaign_achievements.sql
@@ -1,0 +1,31 @@
+-- 008_campaign_achievements.sql
+-- Phase 4 scaffolding: cross-session unlocks.
+-- Spec: workspace:docs/strategy/quest-campaign-charter-2026-04-14.md (Phase 4)
+--
+-- A campaign achievement is a stable slug earned when a set of criteria
+-- (evaluated against quest_session history) fires. Criteria live in
+-- workspace:data/achievements.json and are checked by
+-- scripts/campaign-achievements-check.sh.
+--
+-- Achievements are append-only: once earned, the row is not modified. Later
+-- phases MAY add derived tables (e.g. per-session earnings) on top.
+--
+-- Additive. IF NOT EXISTS throughout.
+
+CREATE TABLE IF NOT EXISTS campaign_achievements (
+  achievement_id     TEXT PRIMARY KEY,          -- stable slug: 'first-legendary', 'dragon-triple'
+  earned_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+  earned_by_session  TEXT NOT NULL,             -- session_id that triggered it
+  criteria           JSONB NOT NULL,            -- snapshot of the rule that fired (audit trail)
+  display_name       TEXT NOT NULL,
+  display_glyph      TEXT NOT NULL DEFAULT '◉'
+);
+
+CREATE INDEX IF NOT EXISTS campaign_achievements_earned_at_idx
+  ON campaign_achievements(earned_at DESC);
+
+CREATE INDEX IF NOT EXISTS campaign_achievements_session_idx
+  ON campaign_achievements(earned_by_session);
+
+COMMENT ON TABLE campaign_achievements IS
+  'Phase 4 scaffolding. Append-only cross-session unlocks. Criteria registry in workspace:data/achievements.json. Populated by scripts/campaign-achievements-check.sh.';


### PR DESCRIPTION
## Summary

Phase 4 (Sanderlanche) scaffolding migrations — additive, IF NOT EXISTS, no behavior change.

- **007** `soul_scorecard` — per-(soul, metric) tally table. Target of workspace `scripts/soul-scorecard-sync.sh`. Metrics: `sessions_led`, `sessions_shipped_in`, `sessions_grey`, `sessions_abandoned`, plus `vetoes_called`/`slices_dropped` stubs.
- **008** `campaign_achievements` — append-only cross-session unlock table. Criteria registry lives in workspace (`data/achievements.json`); populated by workspace `scripts/campaign-achievements-check.sh`.

No auto-wiring into `/go` or `/quest`. These accumulate data; Phase 4 interlock logic activates when the corpus is sufficient (Sanderson's First Law: rules written before write paths).

Applied to Neon 2026-04-13 before commit. Companion workspace PR: `campaign/quest-phase4-scaffold` (scripts, registries, skill update).

## Test plan

- [x] Migrations applied to live Neon DB (verified `\d soul_scorecard` and `\d campaign_achievements`)
- [x] IF NOT EXISTS guards verified (re-ran clean)
- [ ] Integration with workspace scripts verified after workspace PR merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)