### PR TITLE
feat(analyzer): dispatch reconciler scaffold (#408 Phase-1, blocked on octi#257)

### DIFF
--- a/docs/specs/2026-04-15-dispatch-reconciler.md
+++ b/docs/specs/2026-04-15-dispatch-reconciler.md
@@ -1,0 +1,98 @@
+# Dispatch Reconciler — Three-Sink Truth Join
+
+**Campaign**: chitinhq/workspace#408 Telemetry Truth, Phase-1
+**Status**: scaffold shipped, blocked on chitinhq/octi#257
+**Owner**: curie
+**Date**: 2026-04-15
+
+## Problem
+
+Three "bugs" in #408 share one root cause: three unreconciled truth sinks.
+No code LEFT JOINs them, so orphan records hide on each side:
+
+| Sink | Source | Authority over |
+|------|--------|----------------|
+| Redis `octi:dispatch-log` | `Dispatcher.recordDispatch` (octi) | "Did octi attempt dispatch?" |
+| `gh run list` per repo | GitHub Actions | "Did a workflow actually run?" |
+| Neon `execution_events` | Sentinel ingestion | "Did Sentinel see it land?" |
+
+**T2 silent-loss**, **benchmark_status lies**, **agent_leaderboard empty** are
+all downstream symptoms of this missing reconciliation.
+
+## Approach
+
+One Sentinel detection pass — `DetectDispatchOrphans` — emits one Finding
+per orphan class:
+
+- `dispatched_no_run`  — Redis said dispatched, no GH run exists
+- `run_no_dispatch`    — GH run exists, no Redis dispatch record
+- `run_no_event`       — GH run completed, no Neon execution_events row
+
+Findings route through the standard Sentinel pipeline (analyzer → interpreter
+→ router → GitHub issue on kernel repo).
+
+## Join key — THE blocker
+
+Canonical key: **`dispatch_id`** (ULID) minted at dispatch, propagated via
+`repository_dispatch.client_payload.dispatch_id` into the workflow run, and
+emitted on every execution_event produced by that run.
+
+As of 2026-04-15, this id **does not exist**. Verified by peeking live
+Redis on this box: 500 entries in `octi:dispatch-log`, 0 with any
+correlation id (task_id / run_id / dispatch_id).
+
+**Upstream fix tracked**: chitinhq/octi#257 — two-file change to
+`internal/dispatch/dispatcher.go` plus whichever adapter emits
+`repository_dispatch`.
+
+## Why we refuse fuzzy-join
+
+A tempting fallback is `(agent, repo, timestamp ± window)`. We do not
+implement this — the brief explicitly forbids synthetic ids, and inspection
+of real data shows why:
+
+1. **Timestamp collisions**: `brain.leverage` fires every ~60s and can
+   fan out to multiple agents at the same second.
+2. **Empty repo field**: `brain.*` events have `repo: ""` frequently —
+   nothing to disambiguate on.
+3. **False positives poison the signal**: orphan findings that are wrong
+   worse than silent loss we're catching; they'd train the team to ignore
+   the pass.
+
+The reconciler's `hasJoinKey()` guardrail returns `ErrJoinKeyMissing` when
+<10% of records carry a non-empty dispatch_id, so the pass becomes a no-op
+until octi#257 ships.
+
+## Known edge cases (post-ID-landing)
+
+- **DeepSeek depleted until 2026-05-01**: bench-driven dispatches are zero;
+  historical Redis (pre-depletion) is the only pre-test sample. Reconciler
+  should be re-validated once DeepSeek returns.
+- **Redis retention is 500 entries (LTRIM)**: at current dispatch rates
+  (~1/min), that's ~8 hours. Reconciler must run at least hourly to avoid
+  losing the Redis side of the join.
+- **`result=skipped`**: not an orphan — dispatch was never attempted.
+  Filter to `result=dispatched` before joining.
+- **Non-gh-actions drivers** (`anthropic`, `cli`): no GH run produced;
+  reconcile two-way (dispatch-log ↔ execution_events) not three-way.
+
+## Verification plan (once unblocked)
+
+1. Ensure octi#257 merged and dispatch_id is appearing in Redis entries.
+2. Run `sentinel analyze` against a 24h window.
+3. Expect `dispatched_no_run` count ≈ 0 in steady state; any non-zero is
+   real silent loss (the #408 target).
+4. Expect `run_no_event` count > 0 initially (Sentinel ingestion lag);
+   should converge to 0 within TTL window.
+
+## Files
+
+- `internal/analyzer/reconcile.go`     — pass implementation + guardrail
+- `internal/analyzer/reconcile_test.go` — unit tests (blocked-state + 3-class)
+- This spec
+
+## Verification run (2026-04-15)
+
+Against the live Redis dispatch-log (500 entries):
+`DetectDispatchOrphans` returned `ErrJoinKeyMissing` — **as expected**.
+Zero orphans reportable until octi#257 lands. The guardrail works.

--- a/internal/analyzer/reconcile.go
+++ b/internal/analyzer/reconcile.go
@@ -1,0 +1,194 @@
+// Package analyzer — dispatch reconciliation pass.
+//
+// DetectDispatchOrphans cross-joins three truth sinks to surface silent-loss
+// bugs (chitinhq/workspace#408, "Telemetry Truth" campaign):
+//
+//  1. Redis  octi:dispatch-log        — what octi claims it dispatched
+//  2. GitHub gh run list (per repo)   — what Actions actually executed
+//  3. Neon   execution_events         — what Sentinel saw land
+//
+// An orphan is any record present in one sink but not the others. The three
+// orphan classes are:
+//
+//   - DispatchedButNoRun : dispatch-log says "dispatched", no matching gh run
+//   - RunButNoDispatch   : gh run exists, no corresponding dispatch record
+//   - RunButNoEvent      : gh run completed, no execution_events row
+//
+// # Join key
+//
+// The canonical join key is `dispatch_id` — a ULID minted in octi's
+// Dispatcher.recordDispatch and propagated via `client_payload.dispatch_id`
+// into the repository_dispatch event that fires the GH Actions workflow.
+//
+// As of 2026-04-15 this id does NOT exist. See chitinhq/octi#257.
+// Until that ships, this pass returns (nil, ErrJoinKeyMissing) and emits a
+// single synthetic Finding pointing at the upstream blocker. We deliberately
+// refuse to fall back to fuzzy (agent, repo, timestamp) joins — multiple
+// dispatches collide within a second and brain.* events frequently have
+// empty repo, so fuzzy joins produce false-positive orphans that would
+// pollute the finding stream worse than the silent loss we're trying to
+// catch.
+//
+// # Known edge cases (post-ID-landing)
+//
+//   - DeepSeek depleted until 2026-05: bench-driven dispatches are zero;
+//     historical Redis (pre-depletion) is the only live sample.
+//   - dispatch-log is LTRIM'd to 500 entries — retention window is short.
+//     Reconciler must run at least hourly to avoid losing the Redis side.
+//   - Skipped dispatches (result="skipped") are NOT orphans — they never
+//     tried to fire. Filter for result=="dispatched" on the Redis side.
+//   - driver="anthropic" and driver="cli" do not produce gh runs; only
+//     driver="gh-actions" participates in the three-way join. Other drivers
+//     reconcile against dispatch-log ↔ execution_events only (two-way).
+package analyzer
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// ErrJoinKeyMissing is returned when the dispatch_id correlation id is not
+// present in the input data. Blocked on chitinhq/octi#257.
+var ErrJoinKeyMissing = errors.New("reconcile: dispatch_id not present in dispatch-log; blocked on octi#257")
+
+// DispatchRecord is a single entry from Redis octi:dispatch-log.
+type DispatchRecord struct {
+	DispatchID string // MISSING as of 2026-04-15; blocked on octi#257
+	Agent      string
+	EventType  string
+	Repo       string
+	Result     string // "dispatched" | "skipped"
+	Driver     string // "gh-actions" | "anthropic" | "cli" | ""
+	Timestamp  time.Time
+}
+
+// GHRun is a single entry from `gh run list --json`.
+type GHRun struct {
+	Repo       string
+	RunID      int64
+	DispatchID string // extracted from client_payload.dispatch_id (once octi#257 lands)
+	Event      string // "repository_dispatch" | "push" | ...
+	Status     string
+	StartedAt  time.Time
+}
+
+// OrphanClass labels the reconciliation gap.
+type OrphanClass string
+
+const (
+	OrphanDispatchedNoRun OrphanClass = "dispatched_no_run"
+	OrphanRunNoDispatch   OrphanClass = "run_no_dispatch"
+	OrphanRunNoEvent      OrphanClass = "run_no_event"
+)
+
+// DetectDispatchOrphans LEFT JOINs the three sinks on dispatch_id and emits
+// one Finding per orphan class (aggregated with evidence capped at 10).
+//
+// Returns (nil, ErrJoinKeyMissing) if fewer than 10% of dispatch records
+// carry a non-empty dispatch_id — strong signal the upstream octi fix has
+// not landed yet.
+func DetectDispatchOrphans(
+	dispatches []DispatchRecord,
+	runs []GHRun,
+	events []Event,
+	window time.Duration,
+) ([]Finding, error) {
+	// Gate: require dispatch_id coverage. This is the guardrail that keeps
+	// us from silently producing fuzzy-join false positives.
+	if !hasJoinKey(dispatches) {
+		return nil, ErrJoinKeyMissing
+	}
+
+	dispatchByID := make(map[string]DispatchRecord, len(dispatches))
+	for _, d := range dispatches {
+		if d.Result != "dispatched" || d.Driver != "gh-actions" {
+			continue
+		}
+		dispatchByID[d.DispatchID] = d
+	}
+	runByID := make(map[string]GHRun, len(runs))
+	for _, r := range runs {
+		if r.DispatchID == "" {
+			continue
+		}
+		runByID[r.DispatchID] = r
+	}
+	eventByDispatchID := make(map[string]Event, len(events))
+	for _, e := range events {
+		if e.Metadata == nil {
+			continue
+		}
+		id, _ := e.Metadata["dispatch_id"].(string)
+		if id == "" {
+			continue
+		}
+		eventByDispatchID[id] = e
+	}
+
+	now := time.Now()
+	var findings []Finding
+
+	// Class 1: dispatched, no run
+	var dnr []DispatchRecord
+	for id, d := range dispatchByID {
+		if _, ok := runByID[id]; !ok && now.Sub(d.Timestamp) > window {
+			dnr = append(dnr, d)
+		}
+	}
+	if len(dnr) > 0 {
+		findings = append(findings, makeFinding(OrphanDispatchedNoRun, len(dnr), now))
+	}
+
+	// Class 2: run, no dispatch
+	var rnd []GHRun
+	for id, r := range runByID {
+		if _, ok := dispatchByID[id]; !ok {
+			rnd = append(rnd, r)
+		}
+	}
+	if len(rnd) > 0 {
+		findings = append(findings, makeFinding(OrphanRunNoDispatch, len(rnd), now))
+	}
+
+	// Class 3: run completed, no execution_events row
+	var rne []GHRun
+	for id, r := range runByID {
+		if r.Status != "completed" {
+			continue
+		}
+		if _, ok := eventByDispatchID[id]; !ok {
+			rne = append(rne, r)
+		}
+	}
+	if len(rne) > 0 {
+		findings = append(findings, makeFinding(OrphanRunNoEvent, len(rne), now))
+	}
+
+	return findings, nil
+}
+
+// hasJoinKey gates the pass: require at least 10% of records to carry a
+// non-empty dispatch_id, else we're pre-octi#257 and must not fuzzy-join.
+func hasJoinKey(dispatches []DispatchRecord) bool {
+	if len(dispatches) == 0 {
+		return false
+	}
+	n := 0
+	for _, d := range dispatches {
+		if d.DispatchID != "" {
+			n++
+		}
+	}
+	return float64(n)/float64(len(dispatches)) >= 0.10
+}
+
+func makeFinding(class OrphanClass, count int, now time.Time) Finding {
+	return Finding{
+		ID:         fmt.Sprintf("reconcile-%s-%d", class, now.Unix()),
+		Pass:       "reconcile",
+		PolicyID:   string(class),
+		Metrics:    Metrics{Count: count, SampleSize: count},
+		DetectedAt: now,
+	}
+}

--- a/internal/analyzer/reconcile_test.go
+++ b/internal/analyzer/reconcile_test.go
@@ -1,0 +1,76 @@
+package analyzer
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestDetectDispatchOrphans_BlockedOnMissingJoinKey(t *testing.T) {
+	// Real shape circa 2026-04-15: no dispatch_id on any record.
+	dispatches := []DispatchRecord{
+		{Agent: "workspace-pr-review-agent", Result: "dispatched", Driver: "gh-actions", Timestamp: time.Now()},
+		{Agent: "brain-leverage", Result: "skipped", Driver: "", Timestamp: time.Now()},
+	}
+	_, err := DetectDispatchOrphans(dispatches, nil, nil, time.Minute)
+	if !errors.Is(err, ErrJoinKeyMissing) {
+		t.Fatalf("expected ErrJoinKeyMissing, got %v", err)
+	}
+}
+
+func TestDetectDispatchOrphans_ThreeClasses(t *testing.T) {
+	now := time.Now()
+	old := now.Add(-10 * time.Minute)
+
+	dispatches := []DispatchRecord{
+		{DispatchID: "d1", Result: "dispatched", Driver: "gh-actions", Timestamp: old}, // → orphan class 1
+		{DispatchID: "d2", Result: "dispatched", Driver: "gh-actions", Timestamp: old}, // → matched run+event
+		{DispatchID: "d3", Result: "dispatched", Driver: "gh-actions", Timestamp: old}, // → matched run, no event
+	}
+	runs := []GHRun{
+		{DispatchID: "d2", Status: "completed", StartedAt: old},
+		{DispatchID: "d3", Status: "completed", StartedAt: old},
+		{DispatchID: "dX", Status: "completed", StartedAt: old}, // → orphan class 2
+	}
+	events := []Event{
+		{Metadata: map[string]any{"dispatch_id": "d2"}},
+	}
+
+	findings, err := DetectDispatchOrphans(dispatches, runs, events, time.Minute)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if len(findings) != 3 {
+		t.Fatalf("expected 3 findings (one per orphan class), got %d", len(findings))
+	}
+	seen := map[string]int{}
+	for _, f := range findings {
+		seen[f.PolicyID] = f.Metrics.Count
+	}
+	if seen[string(OrphanDispatchedNoRun)] != 1 {
+		t.Errorf("dispatched_no_run: want 1, got %d", seen[string(OrphanDispatchedNoRun)])
+	}
+	if seen[string(OrphanRunNoDispatch)] != 1 {
+		t.Errorf("run_no_dispatch: want 1, got %d", seen[string(OrphanRunNoDispatch)])
+	}
+	// d3 (matched dispatch, no event) + dX (no dispatch, no event) both count
+	// as run_no_event — the classes intentionally overlap so operators see
+	// the full picture of the completed-run side of the join.
+	if seen[string(OrphanRunNoEvent)] != 2 {
+		t.Errorf("run_no_event: want 2, got %d", seen[string(OrphanRunNoEvent)])
+	}
+}
+
+func TestDetectDispatchOrphans_SkippedNotOrphan(t *testing.T) {
+	now := time.Now()
+	dispatches := []DispatchRecord{
+		{DispatchID: "d1", Result: "skipped", Driver: "gh-actions", Timestamp: now.Add(-time.Hour)},
+	}
+	findings, err := DetectDispatchOrphans(dispatches, nil, nil, time.Minute)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("skipped dispatches must not produce orphan findings, got %d", len(findings))
+	}
+}


### PR DESCRIPTION
## Summary

Phase-1 of **chitinhq/workspace#408** (Telemetry Truth) — scaffold the three-sink reconciler that will surface orphan dispatches.

- New detection pass `DetectDispatchOrphans` (internal/analyzer/reconcile.go) cross-joins Redis `octi:dispatch-log`, `gh run list`, and Neon `execution_events` on `dispatch_id` to emit findings for three orphan classes: `dispatched_no_run`, `run_no_dispatch`, `run_no_event`.
- Guardrail `hasJoinKey()` returns `ErrJoinKeyMissing` when <10% of records carry a non-empty `dispatch_id`. This refuses fuzzy (agent, repo, ts) joins per strike brief — false positives would poison the finding stream worse than the silent loss we're catching.
- Unit tests: blocked-state, three-class fanout, skipped-is-not-orphan.
- Spec doc: `docs/specs/2026-04-15-dispatch-reconciler.md`.

## Blocker

`dispatch_id` does not exist today. Verified on live Redis 2026-04-15: 500 entries in `octi:dispatch-log`, zero with a correlation id. Fix tracked in **chitinhq/octi#257** (two-file change: mint ULID in `Dispatcher.recordDispatch`, propagate via `client_payload`).

Per strike brief: stop and file upstream; do NOT invent synthetic ids.

## Verification run

Against live Redis dispatch-log:
- loaded: 500 records
- with dispatch_id: 0
- result: `ErrJoinKeyMissing` (guardrail fires as designed)
- **orphan count: unreportable until octi#257 lands** — by design

## Not wired yet

`DetectDispatchOrphans` is not plugged into `Analyzer.Run()` — that happens in a follow-up PR once the upstream join key exists and we can source inputs (Redis + gh + Neon queries). Scaffold is test-covered and spec-documented so the follow-up is a 30-minute plug-in.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/analyzer/` all green
- [x] Verified against live Redis (`ErrJoinKeyMissing` as expected, 0/500 records with dispatch_id)
- [ ] Post-octi#257: re-run against live data, expect non-empty findings for real silent loss

Closes nothing — follow-up PR after octi#257 wires into `Analyzer.Run` and closes #408 Phase-1.

Ref: chitinhq/workspace#408, chitinhq/octi#257