### PR TITLE
chore(sentinel): scrub Anthropic API ref + retire dead swarm_dispatch adapter

### DIFF
--- a/.github/workflows/sentinel-insights.yml
+++ b/.github/workflows/sentinel-insights.yml
@@ -50,7 +50,6 @@ jobs:
           # Optional. When unset, `analyze --insights-only` logs + exits 0
           # (see runInsightsOnly in cmd/sentinel/main.go). Slice 2 will
           # replace this with an octi-dispatch path.
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           # Optional. Used for insight rate-limit state; generator tolerates
           # absence and just won't rate-limit across runs.
           SENTINEL_REDIS_URL: ${{ secrets.REDIS_URL }}

--- a/sentinel.yaml
+++ b/sentinel.yaml
@@ -74,9 +74,14 @@ ingestion:
     # Empty state_dir disables the adapter.
     state_dir: ${HOME}/.local/state/chitin
     share_dir: ${HOME}/.local/share/chitin
-  swarm_dispatch:
-    # Path to Octi swarm telemetry events file.
-    telemetry_path: ${HOME}/.local/share/octi/telemetry/swarm-events.jsonl
+  # swarm_dispatch adapter RETIRED 2026-04-15: dispatches now flow through
+  # chitin_governance (governance_events table, 116+ flow.swarm.dispatch rows/4h)
+  # not the legacy jsonl file. The adapter reads a file that has been stale since
+  # 2026-04-12 (9 total events). Leaving commented in case we revive.
+  #   swarm_dispatch:
+  #     # Path to Octi swarm telemetry events file.
+  #     telemetry_path: ${HOME}/.local/share/octi/telemetry/swarm-events.jsonl
+
   brain_state:
     enabled: true
     interval: 5m


### PR DESCRIPTION
Two cleanups from overnight-feed session.

1. Scrub ANTHROPIC_API_KEY reference from sentinel-insights workflow (user policy: no Anthropic API; key already empty, code no-ops gracefully — hygiene only).

2. Retire the swarm_dispatch adapter via config comment-out. File it reads has been stale since 2026-04-12; dispatch data already flows via governance_events (116+ rows/4h).

🤖 Generated with Claude Code