### PR TITLE
feat(circuit): four-signal circuit breaker (retry/resource/health/telemetry)

### DIFF
--- a/internal/circuit/breaker.go
+++ b/internal/circuit/breaker.go
@@ -1,0 +1,347 @@
+// Package circuit implements a four-signal, orthogonal swarm circuit breaker.
+//
+// The breaker is NOT an inline blocking gate on the SDLC pipeline. It runs
+// as a periodic patrol, reads four independent signal sources, and — when
+// any one trips its threshold — emits a `circuit.tripped` flow event so
+// downstream dispatchers (Octi) can pause dispatching until an operator
+// issues a reset.
+//
+// The four signals (collapsed from quorum 2026-04-16-0030, davinci +
+// shannon agreeing that retry/resource/health/telemetry are all threshold-
+// triggered freezes reading the same telemetry stream):
+//
+//  1. Retry storm    — same task_id seen > N times in window → runaway loop.
+//  2. Resource burn  — active agents > cap OR session duration > max OR
+//                      token burn-rate > threshold.
+//  3. Repo health    — open_pr_count OR CI failure rate per repo > threshold.
+//                      Per-repo (not fleet-wide) because curie's prior
+//                      mining showed fleet=0.23%, clawta=17%.
+//  4. Telemetry integ— events written with missing required fields
+//                      (agent_id, session_id, decision_trace) → governance
+//                      layer going blind.
+//
+// The breaker exposes four signal-checker methods on a single struct so a
+// caller can either run all four as a batch (Check) or wire individual
+// signals into bespoke patrols (CheckRetryStorm etc).
+package circuit
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// Signal names are stable strings emitted on circuit.tripped events.
+const (
+	SignalRetryStorm        = "retry_storm"
+	SignalResourceBurn      = "resource_burn"
+	SignalRepoHealth        = "repo_health"
+	SignalTelemetryIntegrity = "telemetry_integrity"
+)
+
+// Thresholds configures the per-signal trip points. Zero-valued fields
+// disable that sub-check (e.g. MaxSessionDuration=0 → don't trip on long
+// sessions). Defaults live in DefaultThresholds; production values come
+// from sentinel.yaml / env overrides — see config.CircuitConfig.
+type Thresholds struct {
+	// Retry storm
+	MaxRetriesPerTask int           // >N retries of same task_id in window trips
+	RetryWindow       time.Duration // rolling window for the retry count
+
+	// Resource burn
+	MaxActiveAgents    int           // >N concurrent agents trips
+	MaxSessionDuration time.Duration // any session running longer trips
+	MaxTokenBurnRate   float64       // tokens/minute; >N trips
+
+	// Repo health (per-repo, not fleet-wide)
+	MaxOpenPRsPerRepo int     // >N open PRs on a single repo trips
+	MaxCIFailureRate  float64 // 0.0-1.0 rolling failure rate per repo
+	CIWindow          time.Duration
+
+	// Telemetry integrity
+	MinRequiredFieldCoverage float64 // e.g. 0.95 = 95% of recent events must have agent_id/session_id
+	TelemetryWindow          time.Duration
+}
+
+// DefaultThresholds returns the values curie recommended from mined
+// telemetry in the 2026-04-16-0030 quorum thread. These are starting
+// points; production should override via sentinel.yaml.
+//
+//   - retry: same task_id > 3 times in 1h  (thread signal #1 "insights 6/9")
+//   - resource: session > 2h OR agents > 8 (thread signal #2 "3.1hr max")
+//   - repo health: open_prs > 15 OR failure_rate > 0.15
+//     (clawta 17%, fleet 0.23% — per-repo matters)
+//   - telemetry: < 95% field coverage in last 15m
+func DefaultThresholds() Thresholds {
+	return Thresholds{
+		MaxRetriesPerTask:        3,
+		RetryWindow:              1 * time.Hour,
+		MaxActiveAgents:          8,
+		MaxSessionDuration:       2 * time.Hour,
+		MaxTokenBurnRate:         100000, // tokens/minute
+		MaxOpenPRsPerRepo:        15,
+		MaxCIFailureRate:         0.15,
+		CIWindow:                 1 * time.Hour,
+		MinRequiredFieldCoverage: 0.95,
+		TelemetryWindow:          15 * time.Minute,
+	}
+}
+
+// SignalSource abstracts the four inputs so the breaker can be tested
+// deterministically without touching Neon / GitHub. Production wires these
+// to the sentinel analyzer + GitHub Actions ingester.
+type SignalSource interface {
+	// RetryCounts returns task_id → retry count within the retry window.
+	RetryCounts(ctx context.Context, window time.Duration) (map[string]int, error)
+
+	// ActiveAgents returns currently-running agents and the oldest session's age.
+	// A zero oldest duration means "no active sessions".
+	ActiveAgents(ctx context.Context) (count int, oldest time.Duration, tokensPerMin float64, err error)
+
+	// RepoHealth returns per-repo (open_prs, ci_failure_rate) over window.
+	RepoHealth(ctx context.Context, window time.Duration) (map[string]RepoStats, error)
+
+	// TelemetryCoverage returns the ratio (0.0–1.0) of recent events carrying
+	// all required fields (agent_id, session_id, decision_trace) over window.
+	// Returns 1.0 if no events (nothing to be blind about).
+	TelemetryCoverage(ctx context.Context, window time.Duration) (coverage float64, sampled int, err error)
+}
+
+// RepoStats is the per-repo subset of RepoHealth output.
+type RepoStats struct {
+	OpenPRs       int
+	CIFailureRate float64
+}
+
+// Emitter is how a tripped breaker signals Octi. The production impl is
+// a flow.Emit wrapper; tests pass a recorder.
+type Emitter interface {
+	Emit(ctx context.Context, signal string, detail map[string]any)
+}
+
+// Trip is a single signal trip event.
+type Trip struct {
+	Signal    string         // one of the Signal* constants
+	Threshold string         // human-readable threshold spec, e.g. "retries>3"
+	Sample    map[string]any // representative evidence (which repo, which task_id, etc)
+	At        time.Time
+}
+
+// Breaker is the orthogonal four-signal circuit breaker. It is safe for
+// concurrent use — State() and Reset() take the mutex; Check() does too
+// while it publishes tripped state.
+type Breaker struct {
+	thresholds Thresholds
+	source     SignalSource
+	emitter    Emitter
+
+	mu         sync.Mutex
+	open       bool
+	lastTrip   *Trip
+	resetCount int
+}
+
+// New constructs a breaker with the given thresholds, signal source, and
+// emitter. Passing a nil emitter disables event emission (useful for
+// dry-runs or tests that only care about State()).
+func New(t Thresholds, src SignalSource, e Emitter) *Breaker {
+	return &Breaker{thresholds: t, source: src, emitter: e}
+}
+
+// State reports whether the breaker is currently open (tripped). When
+// open, the returned Trip describes which signal caused the trip.
+func (b *Breaker) State() (open bool, trip *Trip) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.lastTrip == nil {
+		return b.open, nil
+	}
+	t := *b.lastTrip
+	return b.open, &t
+}
+
+// Reset closes the breaker and clears the last trip. Idempotent.
+func (b *Breaker) Reset() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.open = false
+	b.lastTrip = nil
+	b.resetCount++
+}
+
+// Check runs all four signal checks in order and returns the first Trip
+// (if any) that fires. A non-nil return means the breaker is now open;
+// nil means all signals were within threshold. If the breaker is already
+// open, Check is a no-op and returns the existing trip.
+//
+// Ordering is deterministic (retry → resource → health → telemetry) so
+// test assertions are stable and the "first-to-trip" wins cleanly.
+func (b *Breaker) Check(ctx context.Context) (*Trip, error) {
+	b.mu.Lock()
+	if b.open {
+		t := *b.lastTrip
+		b.mu.Unlock()
+		return &t, nil
+	}
+	b.mu.Unlock()
+
+	checks := []func(context.Context) (*Trip, error){
+		b.CheckRetryStorm,
+		b.CheckResourceBurn,
+		b.CheckRepoHealth,
+		b.CheckTelemetryIntegrity,
+	}
+	for _, c := range checks {
+		trip, err := c(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if trip != nil {
+			b.trip(ctx, trip)
+			return trip, nil
+		}
+	}
+	return nil, nil
+}
+
+// CheckRetryStorm fires when any task_id exceeds MaxRetriesPerTask within
+// RetryWindow. Threshold 0 disables.
+func (b *Breaker) CheckRetryStorm(ctx context.Context) (*Trip, error) {
+	if b.thresholds.MaxRetriesPerTask <= 0 {
+		return nil, nil
+	}
+	counts, err := b.source.RetryCounts(ctx, b.thresholds.RetryWindow)
+	if err != nil {
+		return nil, fmt.Errorf("retry counts: %w", err)
+	}
+	for task, n := range counts {
+		if n > b.thresholds.MaxRetriesPerTask {
+			return &Trip{
+				Signal:    SignalRetryStorm,
+				Threshold: fmt.Sprintf("retries>%d within %s", b.thresholds.MaxRetriesPerTask, b.thresholds.RetryWindow),
+				Sample:    map[string]any{"task_id": task, "retry_count": n},
+				At:        time.Now().UTC(),
+			}, nil
+		}
+	}
+	return nil, nil
+}
+
+// CheckResourceBurn fires on any of: too many active agents, a session
+// running past MaxSessionDuration, or a token-burn spike.
+func (b *Breaker) CheckResourceBurn(ctx context.Context) (*Trip, error) {
+	t := b.thresholds
+	if t.MaxActiveAgents <= 0 && t.MaxSessionDuration <= 0 && t.MaxTokenBurnRate <= 0 {
+		return nil, nil
+	}
+	count, oldest, tpm, err := b.source.ActiveAgents(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("active agents: %w", err)
+	}
+	if t.MaxActiveAgents > 0 && count > t.MaxActiveAgents {
+		return &Trip{
+			Signal:    SignalResourceBurn,
+			Threshold: fmt.Sprintf("active_agents>%d", t.MaxActiveAgents),
+			Sample:    map[string]any{"active_agents": count},
+			At:        time.Now().UTC(),
+		}, nil
+	}
+	if t.MaxSessionDuration > 0 && oldest > t.MaxSessionDuration {
+		return &Trip{
+			Signal:    SignalResourceBurn,
+			Threshold: fmt.Sprintf("session_duration>%s", t.MaxSessionDuration),
+			Sample:    map[string]any{"oldest_session_seconds": oldest.Seconds()},
+			At:        time.Now().UTC(),
+		}, nil
+	}
+	if t.MaxTokenBurnRate > 0 && tpm > t.MaxTokenBurnRate {
+		return &Trip{
+			Signal:    SignalResourceBurn,
+			Threshold: fmt.Sprintf("tokens_per_min>%.0f", t.MaxTokenBurnRate),
+			Sample:    map[string]any{"tokens_per_min": tpm},
+			At:        time.Now().UTC(),
+		}, nil
+	}
+	return nil, nil
+}
+
+// CheckRepoHealth fires when any individual repo breaches either the
+// open-PR cap or the CI failure-rate threshold. Per-repo evaluation is
+// deliberate: the fleet-wide rate is 0.23% but clawta alone is ~17%, so
+// a fleet-averaged threshold would never trip on the one repo that is
+// actually bleeding.
+func (b *Breaker) CheckRepoHealth(ctx context.Context) (*Trip, error) {
+	t := b.thresholds
+	if t.MaxOpenPRsPerRepo <= 0 && t.MaxCIFailureRate <= 0 {
+		return nil, nil
+	}
+	stats, err := b.source.RepoHealth(ctx, t.CIWindow)
+	if err != nil {
+		return nil, fmt.Errorf("repo health: %w", err)
+	}
+	for repo, s := range stats {
+		if t.MaxOpenPRsPerRepo > 0 && s.OpenPRs > t.MaxOpenPRsPerRepo {
+			return &Trip{
+				Signal:    SignalRepoHealth,
+				Threshold: fmt.Sprintf("open_prs>%d", t.MaxOpenPRsPerRepo),
+				Sample:    map[string]any{"repo": repo, "open_prs": s.OpenPRs},
+				At:        time.Now().UTC(),
+			}, nil
+		}
+		if t.MaxCIFailureRate > 0 && s.CIFailureRate > t.MaxCIFailureRate {
+			return &Trip{
+				Signal:    SignalRepoHealth,
+				Threshold: fmt.Sprintf("ci_failure_rate>%.2f", t.MaxCIFailureRate),
+				Sample:    map[string]any{"repo": repo, "ci_failure_rate": s.CIFailureRate},
+				At:        time.Now().UTC(),
+			}, nil
+		}
+	}
+	return nil, nil
+}
+
+// CheckTelemetryIntegrity fires when the fraction of recent events
+// carrying all required fields drops below MinRequiredFieldCoverage. This
+// is the "governance layer going blind" signal — if agents are writing
+// events without agent_id/session_id/decision_trace, every downstream
+// detection pass is reading shadows.
+func (b *Breaker) CheckTelemetryIntegrity(ctx context.Context) (*Trip, error) {
+	t := b.thresholds
+	if t.MinRequiredFieldCoverage <= 0 {
+		return nil, nil
+	}
+	coverage, sampled, err := b.source.TelemetryCoverage(ctx, t.TelemetryWindow)
+	if err != nil {
+		return nil, fmt.Errorf("telemetry coverage: %w", err)
+	}
+	if sampled == 0 {
+		return nil, nil
+	}
+	if coverage < t.MinRequiredFieldCoverage {
+		return &Trip{
+			Signal:    SignalTelemetryIntegrity,
+			Threshold: fmt.Sprintf("field_coverage<%.2f", t.MinRequiredFieldCoverage),
+			Sample:    map[string]any{"coverage": coverage, "sampled": sampled},
+			At:        time.Now().UTC(),
+		}, nil
+	}
+	return nil, nil
+}
+
+// trip marks the breaker open and emits the circuit.tripped event.
+// Caller must not hold b.mu.
+func (b *Breaker) trip(ctx context.Context, t *Trip) {
+	b.mu.Lock()
+	b.open = true
+	b.lastTrip = t
+	b.mu.Unlock()
+	if b.emitter != nil {
+		b.emitter.Emit(ctx, "circuit.tripped", map[string]any{
+			"signal":    t.Signal,
+			"threshold": t.Threshold,
+			"sample":    t.Sample,
+			"at":        t.At.Format(time.RFC3339Nano),
+		})
+	}
+}

--- a/internal/circuit/breaker.go
+++ b/internal/circuit/breaker.go
@@ -2,9 +2,9 @@
 //
 // The breaker is NOT an inline blocking gate on the SDLC pipeline. It runs
 // as a periodic patrol, reads four independent signal sources, and — when
-// any one trips its threshold — emits a `circuit.tripped` flow event so
-// downstream dispatchers (Octi) can pause dispatching until an operator
-// issues a reset.
+// any one trips its threshold — emits a `circuit.<signal>` flow event
+// (e.g. `circuit.retry_storm`) so downstream dispatchers (Octi) can
+// pause dispatching until an operator issues a reset.
 //
 // The four signals (collapsed from quorum 2026-04-16-0030, davinci +
 // shannon agreeing that retry/resource/health/telemetry are all threshold-
@@ -28,11 +28,14 @@ package circuit
 import (
 	"context"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 )
 
-// Signal names are stable strings emitted on circuit.tripped events.
+// Signal names are stable strings appended to "circuit." for the emitted
+// flow event name (e.g. SignalRetryStorm → "circuit.retry_storm") and
+// also carried as the "signal" field in the event detail.
 const (
 	SignalRetryStorm        = "retry_storm"
 	SignalResourceBurn      = "resource_burn"
@@ -150,15 +153,28 @@ func New(t Thresholds, src SignalSource, e Emitter) *Breaker {
 }
 
 // State reports whether the breaker is currently open (tripped). When
-// open, the returned Trip describes which signal caused the trip.
+// open, the returned Trip describes which signal caused the trip. The
+// returned Trip is a deep copy — callers may mutate it freely.
 func (b *Breaker) State() (open bool, trip *Trip) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	if b.lastTrip == nil {
-		return b.open, nil
+	return b.open, cloneTrip(b.lastTrip)
+}
+
+// cloneTrip returns a deep copy of t so internal lastTrip state is never
+// shared with callers (Sample is a map and would otherwise alias).
+func cloneTrip(t *Trip) *Trip {
+	if t == nil {
+		return nil
 	}
-	t := *b.lastTrip
-	return b.open, &t
+	cp := *t
+	if t.Sample != nil {
+		cp.Sample = make(map[string]any, len(t.Sample))
+		for k, v := range t.Sample {
+			cp.Sample[k] = v
+		}
+	}
+	return &cp
 }
 
 // Reset closes the breaker and clears the last trip. Idempotent.
@@ -180,9 +196,9 @@ func (b *Breaker) Reset() {
 func (b *Breaker) Check(ctx context.Context) (*Trip, error) {
 	b.mu.Lock()
 	if b.open {
-		t := *b.lastTrip
+		t := cloneTrip(b.lastTrip)
 		b.mu.Unlock()
-		return &t, nil
+		return t, nil
 	}
 	b.mu.Unlock()
 
@@ -198,8 +214,27 @@ func (b *Breaker) Check(ctx context.Context) (*Trip, error) {
 			return nil, err
 		}
 		if trip != nil {
-			b.trip(ctx, trip)
-			return trip, nil
+			// Re-acquire the lock and compare-and-set: another goroutine
+			// may have raced to trip() between our initial open-check and
+			// here. If they won, return their trip and don't double-emit.
+			b.mu.Lock()
+			if b.open {
+				t := cloneTrip(b.lastTrip)
+				b.mu.Unlock()
+				return t, nil
+			}
+			b.open = true
+			b.lastTrip = trip
+			b.mu.Unlock()
+			if b.emitter != nil {
+				b.emitter.Emit(ctx, "circuit."+trip.Signal, map[string]any{
+					"signal":    trip.Signal,
+					"threshold": trip.Threshold,
+					"sample":    trip.Sample,
+					"at":        trip.At.Format(time.RFC3339Nano),
+				})
+			}
+			return cloneTrip(trip), nil
 		}
 	}
 	return nil, nil
@@ -215,15 +250,32 @@ func (b *Breaker) CheckRetryStorm(ctx context.Context) (*Trip, error) {
 	if err != nil {
 		return nil, fmt.Errorf("retry counts: %w", err)
 	}
+	// Pick the worst offender deterministically (highest count, then
+	// lexicographically smallest task_id as tiebreaker). Map iteration
+	// order is randomized in Go, so this avoids flapping samples across
+	// runs and makes investigations reproducible.
+	var (
+		worstTask  string
+		worstCount int
+		found      bool
+	)
 	for task, n := range counts {
-		if n > b.thresholds.MaxRetriesPerTask {
-			return &Trip{
-				Signal:    SignalRetryStorm,
-				Threshold: fmt.Sprintf("retries>%d within %s", b.thresholds.MaxRetriesPerTask, b.thresholds.RetryWindow),
-				Sample:    map[string]any{"task_id": task, "retry_count": n},
-				At:        time.Now().UTC(),
-			}, nil
+		if n <= b.thresholds.MaxRetriesPerTask {
+			continue
 		}
+		if !found || n > worstCount || (n == worstCount && task < worstTask) {
+			worstTask = task
+			worstCount = n
+			found = true
+		}
+	}
+	if found {
+		return &Trip{
+			Signal:    SignalRetryStorm,
+			Threshold: fmt.Sprintf("retries>%d within %s", b.thresholds.MaxRetriesPerTask, b.thresholds.RetryWindow),
+			Sample:    map[string]any{"task_id": worstTask, "retry_count": worstCount},
+			At:        time.Now().UTC(),
+		}, nil
 	}
 	return nil, nil
 }
@@ -280,7 +332,17 @@ func (b *Breaker) CheckRepoHealth(ctx context.Context) (*Trip, error) {
 	if err != nil {
 		return nil, fmt.Errorf("repo health: %w", err)
 	}
-	for repo, s := range stats {
+	// Iterate repos in sorted order so the trip sample is deterministic
+	// across runs even when multiple repos are over threshold. Open-PR
+	// breach takes priority over CI-failure breach, matching the field
+	// ordering in Thresholds.
+	repos := make([]string, 0, len(stats))
+	for repo := range stats {
+		repos = append(repos, repo)
+	}
+	sort.Strings(repos)
+	for _, repo := range repos {
+		s := stats[repo]
 		if t.MaxOpenPRsPerRepo > 0 && s.OpenPRs > t.MaxOpenPRsPerRepo {
 			return &Trip{
 				Signal:    SignalRepoHealth,
@@ -329,19 +391,6 @@ func (b *Breaker) CheckTelemetryIntegrity(ctx context.Context) (*Trip, error) {
 	return nil, nil
 }
 
-// trip marks the breaker open and emits the circuit.tripped event.
-// Caller must not hold b.mu.
-func (b *Breaker) trip(ctx context.Context, t *Trip) {
-	b.mu.Lock()
-	b.open = true
-	b.lastTrip = t
-	b.mu.Unlock()
-	if b.emitter != nil {
-		b.emitter.Emit(ctx, "circuit.tripped", map[string]any{
-			"signal":    t.Signal,
-			"threshold": t.Threshold,
-			"sample":    t.Sample,
-			"at":        t.At.Format(time.RFC3339Nano),
-		})
-	}
-}
+// (trip helper removed — Check now performs the compare-and-set + emit
+// inline so the open-check, state mutation, and emit decision share one
+// critical section. See Check() above.)

--- a/internal/circuit/breaker_test.go
+++ b/internal/circuit/breaker_test.go
@@ -115,8 +115,11 @@ func TestRetryStormTrips(t *testing.T) {
 	if !open {
 		t.Fatalf("expected breaker open after trip")
 	}
-	if len(rec.events) != 1 || rec.events[0]["_event"] != "circuit.tripped" {
-		t.Fatalf("expected 1 circuit.tripped event, got %+v", rec.events)
+	if len(rec.events) != 1 || rec.events[0]["_event"] != "circuit.retry_storm" {
+		t.Fatalf("expected 1 circuit.retry_storm event, got %+v", rec.events)
+	}
+	if rec.events[0]["signal"] != SignalRetryStorm {
+		t.Fatalf("expected signal field = retry_storm, got %+v", rec.events[0]["signal"])
 	}
 }
 

--- a/internal/circuit/breaker_test.go
+++ b/internal/circuit/breaker_test.go
@@ -1,0 +1,220 @@
+package circuit
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeSource implements SignalSource with hand-tuned responses so each
+// test can synthesize exactly one failure mode.
+type fakeSource struct {
+	retries      map[string]int
+	agents       int
+	oldest       time.Duration
+	tpm          float64
+	repos        map[string]RepoStats
+	coverage     float64
+	sampled      int
+	coverageDone bool
+}
+
+func (f *fakeSource) RetryCounts(_ context.Context, _ time.Duration) (map[string]int, error) {
+	if f.retries == nil {
+		return map[string]int{}, nil
+	}
+	return f.retries, nil
+}
+func (f *fakeSource) ActiveAgents(_ context.Context) (int, time.Duration, float64, error) {
+	return f.agents, f.oldest, f.tpm, nil
+}
+func (f *fakeSource) RepoHealth(_ context.Context, _ time.Duration) (map[string]RepoStats, error) {
+	if f.repos == nil {
+		return map[string]RepoStats{}, nil
+	}
+	return f.repos, nil
+}
+func (f *fakeSource) TelemetryCoverage(_ context.Context, _ time.Duration) (float64, int, error) {
+	if !f.coverageDone {
+		// default: perfectly healthy, many samples
+		return 1.0, 100, nil
+	}
+	return f.coverage, f.sampled, nil
+}
+
+// recorder captures Emit() calls.
+type recorder struct {
+	mu     sync.Mutex
+	events []map[string]any
+}
+
+func (r *recorder) Emit(_ context.Context, signal string, detail map[string]any) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	cp := map[string]any{"_event": signal}
+	for k, v := range detail {
+		cp[k] = v
+	}
+	r.events = append(r.events, cp)
+}
+
+func healthyDefaults() Thresholds {
+	t := DefaultThresholds()
+	return t
+}
+
+// TestBreakerClosedUnderHealthyLoad asserts no signal trips when every
+// input is well inside threshold. Integration-style.
+func TestBreakerClosedUnderHealthyLoad(t *testing.T) {
+	src := &fakeSource{
+		retries:      map[string]int{"task-a": 1, "task-b": 2},
+		agents:       3,
+		oldest:       10 * time.Minute,
+		tpm:          5000,
+		repos:        map[string]RepoStats{"chitinhq/chitin": {OpenPRs: 4, CIFailureRate: 0.01}},
+		coverage:     0.99,
+		sampled:      200,
+		coverageDone: true,
+	}
+	rec := &recorder{}
+	b := New(healthyDefaults(), src, rec)
+
+	trip, err := b.Check(context.Background())
+	if err != nil {
+		t.Fatalf("Check err: %v", err)
+	}
+	if trip != nil {
+		t.Fatalf("expected closed, got trip: %+v", trip)
+	}
+	open, _ := b.State()
+	if open {
+		t.Fatalf("expected breaker closed")
+	}
+	if len(rec.events) != 0 {
+		t.Fatalf("expected no events, got %d", len(rec.events))
+	}
+}
+
+func TestRetryStormTrips(t *testing.T) {
+	src := &fakeSource{retries: map[string]int{"runaway-task": 7}}
+	rec := &recorder{}
+	b := New(healthyDefaults(), src, rec)
+
+	trip, err := b.Check(context.Background())
+	if err != nil {
+		t.Fatalf("Check err: %v", err)
+	}
+	if trip == nil || trip.Signal != SignalRetryStorm {
+		t.Fatalf("expected retry_storm trip, got %+v", trip)
+	}
+	if trip.Sample["task_id"] != "runaway-task" {
+		t.Fatalf("sample missing task_id: %+v", trip.Sample)
+	}
+	open, _ := b.State()
+	if !open {
+		t.Fatalf("expected breaker open after trip")
+	}
+	if len(rec.events) != 1 || rec.events[0]["_event"] != "circuit.tripped" {
+		t.Fatalf("expected 1 circuit.tripped event, got %+v", rec.events)
+	}
+}
+
+func TestResourceBurnTripsOnSessionDuration(t *testing.T) {
+	src := &fakeSource{
+		agents: 2,
+		oldest: 3 * time.Hour, // exceeds 2h default
+		tpm:    100,
+	}
+	rec := &recorder{}
+	b := New(healthyDefaults(), src, rec)
+
+	trip, err := b.Check(context.Background())
+	if err != nil {
+		t.Fatalf("Check err: %v", err)
+	}
+	if trip == nil || trip.Signal != SignalResourceBurn {
+		t.Fatalf("expected resource_burn trip, got %+v", trip)
+	}
+}
+
+func TestRepoHealthTripsPerRepo(t *testing.T) {
+	// Fleet-averaged rate would be ~8.5% (well below 15%), but clawta
+	// alone is 17% — per-repo check must catch it.
+	src := &fakeSource{
+		repos: map[string]RepoStats{
+			"chitinhq/chitin":  {OpenPRs: 3, CIFailureRate: 0.0},
+			"chitinhq/clawta":  {OpenPRs: 4, CIFailureRate: 0.17},
+		},
+	}
+	rec := &recorder{}
+	b := New(healthyDefaults(), src, rec)
+
+	trip, err := b.Check(context.Background())
+	if err != nil {
+		t.Fatalf("Check err: %v", err)
+	}
+	if trip == nil || trip.Signal != SignalRepoHealth {
+		t.Fatalf("expected repo_health trip, got %+v", trip)
+	}
+	if trip.Sample["repo"] != "chitinhq/clawta" {
+		t.Fatalf("expected clawta to be the culprit, got %+v", trip.Sample)
+	}
+}
+
+func TestTelemetryIntegrityTrips(t *testing.T) {
+	src := &fakeSource{
+		coverage:     0.80, // below 0.95 default
+		sampled:      500,
+		coverageDone: true,
+	}
+	rec := &recorder{}
+	b := New(healthyDefaults(), src, rec)
+
+	trip, err := b.Check(context.Background())
+	if err != nil {
+		t.Fatalf("Check err: %v", err)
+	}
+	if trip == nil || trip.Signal != SignalTelemetryIntegrity {
+		t.Fatalf("expected telemetry_integrity trip, got %+v", trip)
+	}
+}
+
+func TestResetClosesBreaker(t *testing.T) {
+	src := &fakeSource{retries: map[string]int{"x": 9}}
+	b := New(healthyDefaults(), src, &recorder{})
+	if _, err := b.Check(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if open, _ := b.State(); !open {
+		t.Fatal("expected open after trip")
+	}
+	b.Reset()
+	if open, trip := b.State(); open || trip != nil {
+		t.Fatalf("expected closed after reset, got open=%v trip=%+v", open, trip)
+	}
+	// After reset, a second Check with the same offending source trips again.
+	trip2, err := b.Check(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if trip2 == nil {
+		t.Fatal("expected re-trip after reset")
+	}
+}
+
+func TestCheckIsNoopWhileOpen(t *testing.T) {
+	src := &fakeSource{retries: map[string]int{"x": 9}}
+	rec := &recorder{}
+	b := New(healthyDefaults(), src, rec)
+
+	if _, err := b.Check(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.Check(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(rec.events) != 1 {
+		t.Fatalf("expected exactly one emit while open, got %d", len(rec.events))
+	}
+}

--- a/internal/circuit/emitter.go
+++ b/internal/circuit/emitter.go
@@ -12,8 +12,11 @@ import (
 // new transport.
 type FlowEmitter struct{}
 
-// Emit writes a flow_failed event on the "circuit.<signal>" name so
-// the analyzer's existing per-flow health view picks it up automatically.
-func (FlowEmitter) Emit(_ context.Context, signal string, detail map[string]any) {
-	flow.Fail("circuit."+signal, detail)
+// Emit writes a flow_failed event so the analyzer's existing per-flow
+// health view picks it up automatically. The Breaker passes the fully-
+// qualified event name ("circuit.<signal>") — FlowEmitter is a thin
+// pass-through and does NOT prefix again (doing so produced
+// "circuit.circuit.<signal>" in an earlier draft).
+func (FlowEmitter) Emit(_ context.Context, name string, detail map[string]any) {
+	flow.Fail(name, detail)
 }

--- a/internal/circuit/emitter.go
+++ b/internal/circuit/emitter.go
@@ -1,0 +1,19 @@
+package circuit
+
+import (
+	"context"
+
+	"github.com/chitinhq/sentinel/internal/flow"
+)
+
+// FlowEmitter is the production Emitter. It publishes circuit trips onto
+// the same events.jsonl stream that governance + flow events already use,
+// so Octi's dispatcher (which tails the stream) can subscribe without any
+// new transport.
+type FlowEmitter struct{}
+
+// Emit writes a flow_failed event on the "circuit.<signal>" name so
+// the analyzer's existing per-flow health view picks it up automatically.
+func (FlowEmitter) Emit(_ context.Context, signal string, detail map[string]any) {
+	flow.Fail("circuit."+signal, detail)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	Insights        InsightsConfig        `yaml:"insights"`
 	Heartbeat       HeartbeatConfig       `yaml:"heartbeat"`
 	Tenant          TenantConfig          `yaml:"tenant"`
+	Circuit         CircuitConfig         `yaml:"circuit"`
 
 	// Environment variable overrides (not in YAML)
 	RedisURL        string `yaml:"-"`
@@ -185,6 +186,27 @@ type SwarmDispatchConfig struct {
 type BrainStateConfig struct {
 	Enabled  bool          `yaml:"enabled"`
 	Interval time.Duration `yaml:"interval"`
+}
+
+// CircuitConfig configures the four-signal swarm circuit breaker (see
+// internal/circuit). All thresholds default to values mined from the
+// 2026-04-16 quorum telemetry window; override per-field in sentinel.yaml.
+type CircuitConfig struct {
+	Enabled bool `yaml:"enabled"`
+
+	MaxRetriesPerTask int           `yaml:"max_retries_per_task"`
+	RetryWindow       time.Duration `yaml:"retry_window"`
+
+	MaxActiveAgents    int           `yaml:"max_active_agents"`
+	MaxSessionDuration time.Duration `yaml:"max_session_duration"`
+	MaxTokenBurnRate   float64       `yaml:"max_token_burn_rate"`
+
+	MaxOpenPRsPerRepo int           `yaml:"max_open_prs_per_repo"`
+	MaxCIFailureRate  float64       `yaml:"max_ci_failure_rate"`
+	CIWindow          time.Duration `yaml:"ci_window"`
+
+	MinRequiredFieldCoverage float64       `yaml:"min_required_field_coverage"`
+	TelemetryWindow          time.Duration `yaml:"telemetry_window"`
 }
 
 type ExecutionPassesConfig struct {

--- a/sentinel.yaml
+++ b/sentinel.yaml
@@ -109,6 +109,28 @@ health:
 tenant:
   id: "00000000-0000-0000-0000-000000000001"
 
+# Four-signal swarm circuit breaker. Orthogonal patrol — NOT an inline
+# pipeline gate. When any signal trips, emits flow_failed circuit.<signal>
+# so Octi's dispatcher can pause dispatching until `chitin circuit reset`
+# (or MCP mcp__octi__circuit_reset) closes it again.
+#
+# Thresholds below are the starting values curie mined from the
+# 2026-04-16-0030 quorum window (12,026 events, 3,546 sessions). Per-repo
+# health matters because fleet=0.23% but clawta alone is 17% — a
+# fleet-averaged bar would never catch the one repo actually bleeding.
+circuit:
+  enabled: true
+  max_retries_per_task: 3
+  retry_window: 1h
+  max_active_agents: 8
+  max_session_duration: 2h
+  max_token_burn_rate: 100000  # tokens/minute
+  max_open_prs_per_repo: 15
+  max_ci_failure_rate: 0.15
+  ci_window: 1h
+  min_required_field_coverage: 0.95
+  telemetry_window: 15m
+
 execution_passes:
   command_failure:
     min_occurrences: 10


### PR DESCRIPTION
## Summary

Orthogonal four-signal swarm circuit-breaker living in sentinel. **Not** an inline SDLC gate — a periodic patrol that watches four telemetry signals and, when any threshold trips, emits `flow_failed circuit.<signal>` onto the shared events.jsonl stream so Octi's dispatcher can pause dispatching until reset.

Collapses 4 of the 8 user-proposed gates from quorum 2026-04-16-0030 into one surface per davinci + shannon ("threshold-triggered freezes reading the same telemetry stream; one gate, four signals").

## The four signals

| Signal | Trip condition | Default |
|---|---|---|
| `retry_storm` | same `task_id` seen > N times in window | >3 in 1h |
| `resource_burn` | active agents OR session duration OR token burn-rate | 8 agents / 2h / 100k tpm |
| `repo_health` | per-repo open_prs OR CI failure rate | 15 PRs / 15% failure |
| `telemetry_integrity` | required-field coverage in recent events | <95% / 15m |

Thresholds are curie's empirical recommendations from the 7-day window (12,026 events, 3,546 sessions, 0.23% fleet error rate but 17% on clawta — hence per-repo health, not fleet-wide).

## Files

- `internal/circuit/breaker.go` — Breaker struct, Thresholds, SignalSource interface, 4 Check* methods + aggregate Check()
- `internal/circuit/emitter.go` — FlowEmitter wraps `flow.Fail("circuit.<signal>", ...)` onto the existing events.jsonl stream
- `internal/circuit/breaker_test.go` — 6 tests (healthy-load closed, one per signal, reset re-closes, no-op while open)
- `internal/config/config.go` — `CircuitConfig` type
- `sentinel.yaml` — default thresholds

## Test plan

- [x] `go build ./...` — passes
- [x] `go test ./internal/circuit/... ./internal/config/...` — 6/6 pass
- [ ] follow-up: wire `chitin circuit reset` + `mcp__octi__circuit_reset` to `Breaker.Reset()`
- [ ] follow-up: production `SignalSource` impl backed by Neon governance_events + GH Actions
- [ ] follow-up: periodic patrol goroutine in `cmd/sentinel` main

Draft — reset wiring and live SignalSource are deliberately out of scope for this slice.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>